### PR TITLE
Update Google Analytics HTML data attributes for related content

### DIFF
--- a/templates/feature/app/scripts/components/Ribbon.js
+++ b/templates/feature/app/scripts/components/Ribbon.js
@@ -79,10 +79,9 @@ class Ribbon extends Component {
               <li
                 key={story.id}
                 class={storyClass}
-                ga-on="click"
-                ga-event-category="Related link"
-                ga-event-action={story.url}
-                ga-event-label="trending"
+                ga-event-category="read more"
+                ga-event-action="trending"
+                ga-event-label="apps page"
               >
                 <a href={story.url}>{widont(story.headline)}</a>
               </li>

--- a/templates/feature/app/scripts/components/Story.js
+++ b/templates/feature/app/scripts/components/Story.js
@@ -3,7 +3,7 @@ import { h } from 'preact';
 const Story = ({ headline, url, lead_art, readable_pub_date }) => {
   return (
     <article class="story">
-      <a class="story-link dim" href={url} target="_blank">
+      <a class="story-link dim" href={url} target="_blank" ga-event-category="read more" ga-event-action="automated by tag" ga-event-label="apps page">
         <div class="story-media">
           <div class="story-art">
             <img src={lead_art.thumbnails.letterbox} alt={headline} />


### PR DESCRIPTION
Site-wide, we're updating how we track clicks on related content modules. This update will deploy at the same time as the site wide update. Here's what the new structure looks like: 
- Event category: `read more` (changed from "related link")
- Event action: `trending` or `automated by tag` (feed type)
- Event label: `apps page` (page type) 

This will help us better understand how different related content feeds perform across the site. For example, we have a trending module on the frontpage, story page and apps pages.