### PR TITLE
Add widont tag to feature template title #11

### DIFF
--- a/templates/feature/app/index.html
+++ b/templates/feature/app/index.html
@@ -9,7 +9,7 @@
 {% block content %}
 <div class="container">
   <header class="article-header text-center">
-    <h1 class="article-title">{{ context.title or 'The only member-supported, digital-first, nonpartisan media organization' }}</h1>
+    <h1 class="article-title">{{ context.title or 'The only member-supported, digital-first, nonpartisan media organization' | widont }}</h1>
     <p class="article-byline">
       <span class="article-author">By {%- for author in context.authors or ['Super Cool Corgi', 'Friends'] -%}
       {% if not loop.last %}{{ authorComma() }}{% elif not loop.first %} and{% endif %} {{ author }}

--- a/templates/graphic/app/index.html
+++ b/templates/graphic/app/index.html
@@ -5,7 +5,7 @@
 
 {% block content %}
 <div class="app">
-  <h1 class="graphic-title">{{ context.title }}</h1>
+  <h1 class="graphic-title">{{ context.title | widont }}</h1>
   <p class="graphic-prose">{{ context.prose }}</p>
   <div id="graphic" class="graphic"></div>
   <ul class="graphic-footer">


### PR DESCRIPTION
**Related Github issue:** https://github.com/texastribune/data-visuals-create/issues/11
**Related Basecamp issue:** https://3.basecamp.com/3098728/buckets/80634/todos/1850697841

(I made a Github issue because you can link a commit/PR to a specific Github issue, and track why you made your changes. Also just to see if people think this workflow is useful.)

A couple questions:
- Should a CHANGELOG be added?
- Should a `|widont` tag also be added to the graphic template title?