### PR TITLE
Predeploy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Fixed
 
-
 ## [2.4.1]
 ### Changed
 - `update-log-sheet.js` - change sheet to new 2020 data visuals work sheet
@@ -25,7 +24,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `package.json` - pull assets and push to workspace on predeploy, which is run automatically before deploy #31
 - `feature/app/styles/components/_related-content.scss`, `feature/app/styles/components/_ads.scss`, 
 `processors.html` - update appearance of ads 
-
 
 ## [2.3.2] - 2019-11-26
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `package.json` - pull assets and push to workspace on predeploy, which is run automatically before deploy #31
 - `feature/app/styles/components/_related-content.scss`, `feature/app/styles/components/_ads.scss`, 
 `processors.html` - update appearance of ads 
+- `feature/README.md` - added project launch checklist
 
 ## [2.3.2] - 2019-11-26
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `package.json` - pull assets and push to workspace on predeploy, which is run automatically before deploy #31
 - `feature/app/styles/components/_related-content.scss`, `feature/app/styles/components/_ads.scss`, 
 `processors.html` - update appearance of ads 
-- `feature/README.md` - added project launch checklist
+- `graphic/README.md, feature/README.md` - added project launch checklist
 
 ## [2.3.2] - 2019-11-26
 ### Changed

--- a/templates/__common__/README.md
+++ b/templates/__common__/README.md
@@ -4,6 +4,60 @@ This `<<type>>` was created using [`data-visuals-create`](https://github.com/tex
 
 <!-- ONLY EDIT BELOW THIS LINE -->
 
+## Project launch checklist
+
+This is a running list of things you should do before you launch any project on one of our apps pages. It's compiled by the data visuals team and uses Markdown. It can be copied and pasted into a MD file and put into [the project's repo](https://github.com/texastribune/redistricting-CD27/blob/master/checklist.md).
+
+Our process for pitching and executing projects (which should happen before all of this) can be found on [this doc](https://docs.google.com/document/d/1E7QE8gp29h20EAafzSui8VjQ_9TG5-XhR33tbAP0hBA/edit).
+
+### Editing checklist
+- [ ] Data visuals editor
+- [ ] Story reporter
+- [ ] Story editor
+- [ ] Secret DV team channel
+- [ ] Secret design feedback channel
+- [ ] Copy editor
+
+### Headline
+- [ ] Get a headline by submitting the story's budget line to the Headline Hoedown Slack channel
+
+### Article
+- [ ] Add ads (three is typically the minimum; add more if longer)
+- [ ] Make sure it has related articles
+- [ ] Check Facebook debugger after deploy
+- [ ] Check Parsely validation after deploy
+- [ ] Add share art to top of the page
+- [ ] Get social buttons showing on mobile
+
+### Social
+- [ ] Check with social team about promotion
+- [ ] Review Bobby’s promo materials (he likes to make gifs and other cool things)
+- [ ] Review social blasts (Tweet storms, Facebook posts, etc.)
+
+### Browser testing
+A full list of browsers we support is available on this Confluence page. Please go through the list and test all devices listed:
+- [ ] Mobile: Safari
+- [ ] Mobile: Chrome
+- [ ] Mobile: Facebook
+- [ ] Desktop: Chrome
+- [ ] Desktop: Safari
+- [ ] Desktop: Edge
+- [ ] Desktop: Firefox
+- [ ] Tablet: Safari
+
+### Post-deploy tasks
+- [ ] Make sure everything works on live url
+
+### Media partners
+If we have media partners, we need to make sure they have everything they need to post our content on their set
+- [ ] Get Google doc set up for partners
+- [ ] Pull text of story into Google doc
+- [ ] Get art to take screenshots of the charts and put them into the Google doc (if necessary)
+- [ ] Send Illustrator files of graphics to their team (if necessary)
+
+### Other
+- [ ] Make an embed for stories
+
 ## Available commands
 
 All project templates share the same build commands.

--- a/templates/__common__/README.md
+++ b/templates/__common__/README.md
@@ -6,7 +6,7 @@ This `<<type>>` was created using [`data-visuals-create`](https://github.com/tex
 
 ## Project launch checklist
 
-This is a running list of things you should do before you launch any project on one of our apps pages. It's compiled by the data visuals team and uses Markdown. It can be copied and pasted into a MD file and put into [the project's repo](https://github.com/texastribune/redistricting-CD27/blob/master/checklist.md).
+This is a running list of things you should do before you launch any project on one of our apps pages.
 
 Our process for pitching and executing projects (which should happen before all of this) can be found on [this doc](https://docs.google.com/document/d/1E7QE8gp29h20EAafzSui8VjQ_9TG5-XhR33tbAP0hBA/edit).
 
@@ -23,7 +23,7 @@ Our process for pitching and executing projects (which should happen before all 
 
 ### Article
 - [ ] Add ads (three is typically the minimum; add more if longer)
-- [ ] Make sure it has related articles
+- [ ] Make sure there's related articles
 - [ ] Check Facebook debugger after deploy
 - [ ] Check Parsely validation after deploy
 - [ ] Add share art to top of the page
@@ -31,7 +31,7 @@ Our process for pitching and executing projects (which should happen before all 
 
 ### Social
 - [ ] Check with social team about promotion
-- [ ] Review Bobby’s promo materials (he likes to make gifs and other cool things)
+- [ ] Review social media editor's promo materials (could include GIF's, promo images, etc.)
 - [ ] Review social blasts (Tweet storms, Facebook posts, etc.)
 
 ### Browser testing
@@ -46,14 +46,15 @@ A full list of browsers we support is available on this Confluence page. Please 
 - [ ] Tablet: Safari
 
 ### Post-deploy tasks
-- [ ] Make sure everything works on live url
+- [ ] Make sure everything works on the live url
 
 ### Media partners
-If we have media partners, we need to make sure they have everything they need to post our content on their set
+If we have media partners, we need to make sure they have everything they need to post our content on their set.
+
 - [ ] Get Google doc set up for partners
-- [ ] Pull text of story into Google doc
-- [ ] Get art to take screenshots of the charts and put them into the Google doc (if necessary)
-- [ ] Send Illustrator files of graphics to their team (if necessary)
+- [ ] Pull text of story into a Google Doc
+- [ ] Get art to take screenshots of the charts and put them into the Google Doc (if necessary)
+- [ ] Send Illustrator files of graphics to the partner's team (if necessary)
 
 ### Other
 - [ ] Make an embed for stories

--- a/templates/__common__/_package.json
+++ b/templates/__common__/_package.json
@@ -8,7 +8,7 @@
     "deploy": "node ./utils/deployment/deploy.js",
     "data:fetch": "node ./utils/fetch/get-data.js",
     "git-pre-commit": "precise-commits",
-    "predeploy": "npm run build && npm run assets:push",
+    "predeploy": "npm run assets:pull && npm run build && npm run assets:push && npm run workspace:push",
     "preinstall": "node ./config/build/yarn-check.js",
     "serve": "npm start",
     "start": "NODE_ENV=development node ./config/scripts/develop.js",

--- a/templates/__common__/app/templates/macros/processors.html
+++ b/templates/__common__/app/templates/macros/processors.html
@@ -19,10 +19,16 @@
 {% endmacro %}
 
 {% macro ad(value) %}
-<aside class="story-ad{% if value.align %} story-ad--{{ value.align }}{% endif %}">
-  <p class="story-ad__label">The Texas Tribune thanks its sponsors. <a href="https://mediakit.texastribune.org/">Become one</a>.</p>
-  <div class="story-ad__container">
-    <div class="dv-gpt-ad"></div>
+<div class="plugin plugin--centered">
+  <div class="c-ad-flex">
+    <div class="c-ad-flex__inner">
+      <p class="c-ad-flex__thanks">The Texas Tribune thanks its sponsors. 
+        <a href="https://mediakit.texastribune.org/"><strong>Become one</strong></a>.
+      </p>
+      <div class="c-ad-flex__unit">
+        <div class="dv-gpt-ad"></div>
+      </div>
+    </div>
   </div>
-</aside>
+</div>
 {% endmacro %}

--- a/templates/__common__/app/templates/macros/processors.html
+++ b/templates/__common__/app/templates/macros/processors.html
@@ -20,7 +20,7 @@
 
 {% macro ad(value) %}
 <div class="plugin plugin--centered">
-  <div class="c-ad-flex">
+  <div class="c-ad-flex_bg--{{ value }}">
     <div class="c-ad-flex__inner">
       <p class="c-ad-flex__thanks">The Texas Tribune thanks its sponsors. 
         <a href="https://mediakit.texastribune.org/"><strong>Become one</strong></a>.

--- a/templates/feature/README.md
+++ b/templates/feature/README.md
@@ -1,0 +1,132 @@
+# <<title>>
+
+This `<<type>>` was created using [`data-visuals-create`](https://github.com/texastribune/data-visuals-create) <<createVersion>> on <<year>>-<<month>>-<<day>>.
+
+<!-- ONLY EDIT BELOW THIS LINE -->
+
+## Project launch checklist
+
+This is a running list of things you should do before you launch any project on one of our apps pages.
+
+Our process for pitching and executing projects (which should happen before all of this) can be found on [this doc](https://docs.google.com/document/d/1E7QE8gp29h20EAafzSui8VjQ_9TG5-XhR33tbAP0hBA/edit).
+
+### Editing checklist
+- [ ] Data visuals editor
+- [ ] Story reporter
+- [ ] Story editor
+- [ ] Secret DV team channel
+- [ ] Secret design feedback channel
+- [ ] Copy editor
+
+### Headline
+- [ ] Get a headline by submitting the story's budget line to the Headline Hoedown Slack channel
+
+### Article
+- [ ] Add ads (three is typically the minimum; add more if longer)
+- [ ] Make sure there's related articles
+- [ ] Check Facebook debugger after deploy
+- [ ] Check Parsely validation after deploy
+- [ ] Add share art to top of the page
+- [ ] Get social buttons showing on mobile
+
+### Social
+- [ ] Check with social team about promotion
+- [ ] Review social media editor's promo materials (could include GIF's, promo images, etc.)
+- [ ] Review social blasts (Tweet storms, Facebook posts, etc.)
+
+### Browser testing
+A full list of browsers we support is available on this Confluence page. Please go through the list and test all devices listed:
+
+- [ ] Mobile: Safari
+- [ ] Mobile: Chrome
+- [ ] Mobile: Facebook
+- [ ] Desktop: Chrome
+- [ ] Desktop: Safari
+- [ ] Desktop: Edge
+- [ ] Desktop: Firefox
+- [ ] Tablet: Safari
+
+### Post-deploy tasks
+- [ ] Make sure everything works on the live url
+
+### Media partners
+If we have media partners, we need to make sure they have everything they need to post our content on their set.
+
+- [ ] Get Google doc set up for partners
+- [ ] Pull text of story into a Google Doc
+- [ ] Get art to take screenshots of the charts and put them into the Google Doc (if necessary)
+- [ ] Send Illustrator files of graphics to the partner's team (if necessary)
+
+### Other
+- [ ] Make an embed for stories
+
+## Final editing checklist
+
+Before your embedded graphic or feature goes live, here's the editing steps you need to take: 
+
+- [ ] Spell check and self-edit — does everything make sense? 
+- [ ] Data visuals editor for a visual edit
+- [ ] Design feedback channel (optional for more complex graphics or apps)
+- [ ] Story reporter, if a collaboration 
+- [ ] Story or beat editor for a line edit to check facts
+- [ ] DV team in the secret channel (for a final gut check) 
+- [ ] Copy editor
+- [ ] Be available the night before publication for any last-minute changes, or let other DV teammates know how to make edits
+
+## Available commands
+
+All project templates share the same build commands.
+
+#### `npm start` or `npm run serve`
+
+The main command for development. This will build your HTML pages, prepare your SCSS files and compile your JavaScript. A local server is set up so you can view the project in your browser.
+
+#### `npm run deploy`
+
+The main command for deployment. It will always run `npm run build` first to ensure the compiled version is up-to-date. Use this when you want to put your project online. This will use the `bucket` and `folder` values in the `project.config.js` file to determine where it should be deployed on S3. Make sure those are set the appropriate values!
+
+#### `npm run data:fetch`
+
+This command uses the array of files listed under the `files` key in `project.config.js` to download data to the project. This data will be processed and made available in the `data` folder in the root of the project.
+
+You can also set `dataDir` in `project.config.js` to change the location of that directory if necessary.
+
+#### `npm run assets:push`
+
+This pushes all the raw files found in the `app/assets` directory to S3 to a `raw_assets` directory. This makes it possible for collaborators on the project to sync up with your assets when they run `npm run assets:pull`. This prevents potentially large assets like photos and audio clips from ending up in GitHub. This also runs automatically when `npm run deploy` is used.
+
+#### `npm run assets:pull`
+
+Pulls any raw assets that have been pushed to S3 back down to the project's `app/assets` directory. Good for ensuring you have the same files as anyone else who is working on the project.
+
+#### `npm run workspace:push`
+
+The `workspace` directory is for storing all of your analysis, production and raw data files. It's important to use this directory for these files (instead of `assets` or `data`) so we can keep them out of GitHub. This command will push the contents of the `workspace` directory to S3.
+
+#### `npm run workspace:pull`
+
+Pulls any `workspace` files that have been pushed to S3 back down to the project's local `workspace` directory. This is helpful for ensuring you're in sync with another developer.
+
+## Environment variables and authentication
+
+Any projects created with `data-visuals-create` assume you're working within a Texas Tribune environment, but it is possible to point AWS (used for deploying the project and assets to S3) and Google's API (used for interfacing with Google Drive) at your own credentials.
+
+### AWS
+
+Projects created with `data-visuals-create` support two of the built-in ways that `aws-sdk` can authenticate. If you are already set up with the [AWS shared credentials file](https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/loading-node-credentials-shared.html) (and those credentials are allowed to interact with your S3 buckets), you're good to go. `aws-sdk` will also recognize the [AWS credential environmental variables](https://docs.aws.amazon.com/sdk-for-javascript/v2/developer-guide/loading-node-credentials-environment.html).
+
+### Google
+
+The interface with Google Drive within `data-visuals-create` projects currently only supports using Oauth2 credentials to speak to the Google APIs. This requires a set of OAuth2 credentials that will be used to generate and save an access token to your computer. `data-visuals-create` projects have hardcoded locations for the credential file and token file, but you may override those with environmental variables.
+
+#### CLIENT_SECRETS_FILE
+
+**default**: `~/.tt_kit_google_client_secrets.json`
+
+#### GOOGLE_TOKEN_FILE
+
+**default**: `~/.google_drive_fetch_token`
+
+## License
+
+MIT

--- a/templates/feature/README.md
+++ b/templates/feature/README.md
@@ -10,13 +10,17 @@ This is a running list of things you should do before you launch any project on 
 
 Our process for pitching and executing projects (which should happen before all of this) can be found on [this doc](https://docs.google.com/document/d/1E7QE8gp29h20EAafzSui8VjQ_9TG5-XhR33tbAP0hBA/edit).
 
-### Editing checklist
-- [ ] Data visuals editor
-- [ ] Story reporter
-- [ ] Story editor
-- [ ] Secret DV team channel
-- [ ] Secret design feedback channel
+## Final editing checklist
+Before your embedded graphic or feature goes live, here's the editing steps you need to take: 
+
+- [ ] Spell check and self-edit — does everything make sense? 
+- [ ] Data visuals editor for a visual edit
+- [ ] Design feedback channel (optional for more complex graphics or apps)
+- [ ] Story reporter, if a collaboration 
+- [ ] Story or beat editor for a line edit to check facts
+- [ ] DV team in the secret channel (for a final gut check) 
 - [ ] Copy editor
+- [ ] Be available the night before publication for any last-minute changes, or let other DV teammates know how to make edits
 
 ### Headline
 - [ ] Get a headline by submitting the story's budget line to the Headline Hoedown Slack channel
@@ -59,19 +63,6 @@ If we have media partners, we need to make sure they have everything they need t
 
 ### Other
 - [ ] Make an embed for stories
-
-## Final editing checklist
-
-Before your embedded graphic or feature goes live, here's the editing steps you need to take: 
-
-- [ ] Spell check and self-edit — does everything make sense? 
-- [ ] Data visuals editor for a visual edit
-- [ ] Design feedback channel (optional for more complex graphics or apps)
-- [ ] Story reporter, if a collaboration 
-- [ ] Story or beat editor for a line edit to check facts
-- [ ] DV team in the secret channel (for a final gut check) 
-- [ ] Copy editor
-- [ ] Be available the night before publication for any last-minute changes, or let other DV teammates know how to make edits
 
 ## Available commands
 

--- a/templates/feature/app/index.html
+++ b/templates/feature/app/index.html
@@ -24,7 +24,9 @@
   </header>
 
   {% include 'includes/shares.html' %}
+</div>
 
+<div class="container">
   <div class="intro-prose">
     {{ prose(context.prose, context, data) }}
     <p class="copy">Duis mattis orci a porta maximus. Pellentesque vel pellentesque augue, a condimentum nibh. Integer eget feugiat turpis, at vehicula metus. Vestibulum arcu dui, hendrerit sed purus sed, vulputate aliquam est. Duis quis metus sed odio commodo dapibus. Maecenas pulvinar elit sit amet lorem iaculis blandit. Aliquam vitae sollicitudin urna. Sed viverra tincidunt felis.</p>
@@ -37,7 +39,16 @@
   </div>
 </div>
 
-{{ ad() }}
+{# use 'none' as the value if the ad shoud not have a gray background #}
+{{ ad('gray') }}
+
+<div class="container">
+  <p class="copy">Curabitur vestibulum sagittis diam, vitae pulvinar lorem accumsan ut. Mauris enim massa, vestibulum sed sollicitudin dapibus, ultrices eget ligula. Aenean tempor mi urna, eu porta tortor vehicula quis. Morbi hendrerit, eros nec interdum tempus, sem purus fringilla leo, ut iaculis urna tortor id diam. Duis laoreet maximus sapien, sed scelerisque sapien volutpat vel. Sed est lacus, sollicitudin nec euismod eu, placerat eget turpis. Quisque ultricies urna et mollis bibendum. Quisque tempus, elit ut faucibus hendrerit, augue enim faucibus massa, eu scelerisque dui eros at dolor. Sed rutrum, ipsum id convallis facilisis, justo ex rhoncus ex, in ultrices nisi augue vitae erat. Donec consequat ipsum ac nunc aliquam, eu porttitor quam viverra. Praesent ultrices, diam eget placerat sodales, magna magna porttitor urna, nec mollis ipsum odio at magna. Nulla ac consectetur turpis. Cras non ligula elementum, aliquet arcu ut, interdum nulla.</p>
+
+  <p class="copy">Nam ornare ante eget erat egestas, eget pulvinar diam tincidunt. Nunc eget ligula ac mi facilisis tempus. Proin molestie nisl at urna pharetra commodo. Praesent tincidunt vestibulum purus, id dictum tortor aliquet ac. Pellentesque semper scelerisque justo ac luctus. Nullam malesuada urna a magna fringilla bibendum. Mauris quis hendrerit nisl, a lacinia lectus.</p>
+</div>
+
+{{ ad('gray') }}
 
 <div class="related-content" id="related-content-container"></div>
 

--- a/templates/feature/app/index.html
+++ b/templates/feature/app/index.html
@@ -40,8 +40,10 @@
 </div>
 
 {# use 'none' as the value if the ad shoud not have a gray background #}
+{# do not put ads inside a container div #}
 {{ ad('gray') }}
 
+{# create another container for more prose if the text needs to be split by an ad #}
 <div class="container">
   <p class="copy">Curabitur vestibulum sagittis diam, vitae pulvinar lorem accumsan ut. Mauris enim massa, vestibulum sed sollicitudin dapibus, ultrices eget ligula. Aenean tempor mi urna, eu porta tortor vehicula quis. Morbi hendrerit, eros nec interdum tempus, sem purus fringilla leo, ut iaculis urna tortor id diam. Duis laoreet maximus sapien, sed scelerisque sapien volutpat vel. Sed est lacus, sollicitudin nec euismod eu, placerat eget turpis. Quisque ultricies urna et mollis bibendum. Quisque tempus, elit ut faucibus hendrerit, augue enim faucibus massa, eu scelerisque dui eros at dolor. Sed rutrum, ipsum id convallis facilisis, justo ex rhoncus ex, in ultrices nisi augue vitae erat. Donec consequat ipsum ac nunc aliquam, eu porttitor quam viverra. Praesent ultrices, diam eget placerat sodales, magna magna porttitor urna, nec mollis ipsum odio at magna. Nulla ac consectetur turpis. Cras non ligula elementum, aliquet arcu ut, interdum nulla.</p>
 

--- a/templates/feature/app/index.html
+++ b/templates/feature/app/index.html
@@ -41,8 +41,6 @@
 
 <div class="related-content" id="related-content-container"></div>
 
-{{ ad() }}
-
 <div id="ribbon-container"></div>
 {% endblock content %}
 

--- a/templates/feature/app/styles/components/_ads.scss
+++ b/templates/feature/app/styles/components/_ads.scss
@@ -1,3 +1,53 @@
+.plugin {
+  clear: both;
+
+  .plugin--centered {
+    margin: 2.5rem auto;
+  }
+}
+
+.c-ad-flex {
+  align-items: center;
+  background-color: #fbfbfb;
+  display: flex;
+  height: 320px;
+  justify-content: center;
+}
+
+.c-ad-flex__thanks {
+  color: $color-secondary;
+  text-align: center;
+  font-family: $font-sans-serif;
+  font-size: to-rem(11);
+  line-height: $line-height-subtitle;
+  margin-bottom: 0.85rem;
+
+  strong {
+    font-weight: 700;
+  }
+
+  > a {
+    color: $color-tribune-blue;
+    text-decoration: none;
+
+    &:active,
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+}
+
+.c-ad-flex__unit {
+  background-color: $color-offwhite;
+  margin-left: auto;
+  margin-right: auto;
+  width: 100%;
+
+  @include mq($from: m) {
+    height: 90px;
+  }
+}
+
 .story-ad {
   margin-bottom: $gutter-double;
   margin-left: auto;
@@ -23,33 +73,5 @@
     float: right;
     margin-left: $gutter-double;
     margin-right: 15%;
-  }
-}
-
-.story-ad__label {
-  color: lighten($color-text, 25%);
-  font-family: $font-sans-serif;
-  font-size: to-rem(11);
-  line-height: $line-height-subtitle;
-  margin-bottom: $gutter-quarter;
-
-  > a {
-    color: $color-tribune-blue;
-    text-decoration: none;
-
-    &:active,
-    &:hover {
-      text-decoration: underline;
-    }
-  }
-}
-
-.story-ad__container {
-  background-color: $color-offwhite;
-  height: 250px;
-  width: 100%;
-
-  @include mq($from: m) {
-    height: 90px;
   }
 }

--- a/templates/feature/app/styles/components/_ads.scss
+++ b/templates/feature/app/styles/components/_ads.scss
@@ -6,11 +6,17 @@
   }
 }
 
-.c-ad-flex {
+.c-ad-flex_bg--gray {
   align-items: center;
   background-color: #fbfbfb;
   display: flex;
   height: 320px;
+  justify-content: center;
+}
+
+.c-ad-flex_bg--none {
+  align-items: center;
+  display: flex;
   justify-content: center;
 }
 

--- a/templates/feature/app/styles/components/_related-content.scss
+++ b/templates/feature/app/styles/components/_related-content.scss
@@ -2,6 +2,7 @@
   margin-left: auto;
   margin-right: auto;
   margin-top: $gutter-double;
+  margin-bottom: $gutter-double;
   max-width: to-rem(992);
   padding-left: $gutter;
   padding-right: $gutter;

--- a/templates/feature/project.config.js
+++ b/templates/feature/project.config.js
@@ -17,7 +17,7 @@ module.exports = {
    */
   projectType: 'feature',
   /**
-   * Slug of the project.
+   * What slug was passed in on creation.
    */
   slug: '<<slug>>',
   /**

--- a/templates/graphic/README.md
+++ b/templates/graphic/README.md
@@ -4,60 +4,18 @@ This `<<type>>` was created using [`data-visuals-create`](https://github.com/tex
 
 <!-- ONLY EDIT BELOW THIS LINE -->
 
-## Project launch checklist
+## Final editing checklist
 
-This is a running list of things you should do before you launch any project on one of our apps pages.
+Before your embedded graphic or feature goes live, here's the editing steps you need to take: 
 
-Our process for pitching and executing projects (which should happen before all of this) can be found on [this doc](https://docs.google.com/document/d/1E7QE8gp29h20EAafzSui8VjQ_9TG5-XhR33tbAP0hBA/edit).
-
-### Editing checklist
-- [ ] Data visuals editor
-- [ ] Story reporter
-- [ ] Story editor
-- [ ] Secret DV team channel
-- [ ] Secret design feedback channel
+- [ ] Spell check and self-edit — does everything make sense? 
+- [ ] Data visuals editor for a visual edit
+- [ ] Design feedback channel (optional for more complex graphics or apps)
+- [ ] Story reporter, if a collaboration 
+- [ ] Story or beat editor for a line edit to check facts
+- [ ] DV team in the secret channel (for a final gut check) 
 - [ ] Copy editor
-
-### Headline
-- [ ] Get a headline by submitting the story's budget line to the Headline Hoedown Slack channel
-
-### Article
-- [ ] Add ads (three is typically the minimum; add more if longer)
-- [ ] Make sure there's related articles
-- [ ] Check Facebook debugger after deploy
-- [ ] Check Parsely validation after deploy
-- [ ] Add share art to top of the page
-- [ ] Get social buttons showing on mobile
-
-### Social
-- [ ] Check with social team about promotion
-- [ ] Review social media editor's promo materials (could include GIF's, promo images, etc.)
-- [ ] Review social blasts (Tweet storms, Facebook posts, etc.)
-
-### Browser testing
-A full list of browsers we support is available on this Confluence page. Please go through the list and test all devices listed:
-- [ ] Mobile: Safari
-- [ ] Mobile: Chrome
-- [ ] Mobile: Facebook
-- [ ] Desktop: Chrome
-- [ ] Desktop: Safari
-- [ ] Desktop: Edge
-- [ ] Desktop: Firefox
-- [ ] Tablet: Safari
-
-### Post-deploy tasks
-- [ ] Make sure everything works on the live url
-
-### Media partners
-If we have media partners, we need to make sure they have everything they need to post our content on their set.
-
-- [ ] Get Google doc set up for partners
-- [ ] Pull text of story into a Google Doc
-- [ ] Get art to take screenshots of the charts and put them into the Google Doc (if necessary)
-- [ ] Send Illustrator files of graphics to the partner's team (if necessary)
-
-### Other
-- [ ] Make an embed for stories
+- [ ] Be available the night before publication for any last-minute changes, or let other DV teammates know how to make edits
 
 ## Available commands
 


### PR DESCRIPTION
Closes #31 

### Changed
- `package.json` - pull assets and push to workspace on predeploy, which is run automatically before deploy #31
- `feature/app/styles/components/_related-content.scss`, `feature/app/styles/components/_ads.scss`, 
`processors.html` - update appearance of ads 
- `feature/README.md` - added project launch checklist

### To test
- [x] Checkout branch `predeploy` on this repo.
- [x] Create a graphic with this version of `data-visuals-create` by navigating to your graphics folder, and using the path to the data-visuals-create build script instead of `npx @data-visuas/create` (i.e. for me, it's `../data-visuals-create/bin/data-visuals-create`).
- [x] Put a sample .AI file in the `workspace/` and generate graphics from it, so that you have `assets/` as well.
- [x] Run `npm run deploy`.
- [x] You should see your assets and workspace materials getting pushed up.
- [x] If you want to be super sure, log in to the Tribune's AWS account and go to S3. You can check if your assets and workspace have been pushed up by checking the graphics bucket. Poke Mandi to walk you through this because the AWS interface is .... not user friendly
- [x] Create a feature and check out the ads. They should look like the ads on the main site.