### PR TITLE
Change sheet to 2020 work sheet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Fixed
 
+## [2.4.1]
+### Changed
+- `update-log-sheet.js` - change sheet to new 2020 data visuals work sheet
+
 ## [2.3.2] - 2019-11-26
 ### Changed
 - `graphic/app/scripts/embeds/frames.js` - don't pass debounced function to resize listener, simplify code #29

--- a/templates/__common__/utils/deployment/update-log-sheet.js
+++ b/templates/__common__/utils/deployment/update-log-sheet.js
@@ -25,7 +25,7 @@ let updateLogSheet = async (mainPath, config) => {
   });
 
   // id of data visuals work spreadsheet
-  const spreadsheetId = '13xpogQKMcA_5rHxs7TAWP4mG9KSF8t_3C4TaeHW-I1M';
+  const spreadsheetId = '12CvXDGLJZfTPnaZQjwgaQzyD0qufWWkXd1kACKziBrw';
   let sheetName, repoName;
 
   if (config.projectType === 'graphic') {


### PR DESCRIPTION
### Changed
- `graphic/app/scripts/embeds/frames.js` - don't pass debounced function to resize listener, simplify code #29

### To test
- [ ] Checkout branch `switch-2020` on this repo.
- [ ] Create a graphic with this version of `data-visuals-create` by navigating to your graphics folder, and using the path to the data-visuals-create build script instead of `npx @data-visuas/create` (i.e. for me, it's `../data-visuals-create/bin/data-visuals-create`).
- [ ] Run `npm run deploy` inside of the new graphic.
- [ ] You should see a row with the graphic and its ID added to our [new 2020 data visuals work sheet](https://docs.google.com/spreadsheets/d/12CvXDGLJZfTPnaZQjwgaQzyD0qufWWkXd1kACKziBrw/edit#gid=0).