### PR TITLE
Add option to remove unused CSS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Fixed
 
+## [2.6.0] - 2020-05-08
+### Added
+- `templates/__common__/config/tasks/unused-css.js` - A step that looks at the CSS file linked in any .html file, parses that CSS, and writes new CSS based only on what the HTML needs through the magic of this wonderful tool, [purgecss](https://github.com/FullHuman/purgecss)
+
+### Changed
+- `templates/__common__/config/scripts/build.js` - This cleanup step will now run right after the HTML of the templates compile and before the file revving step
+- `templates/__common__/config/tasks/serve.js` - New watchers added mostly in the build output folder to re-run the CSS cleanup step after the build
+- `templates/__common__/_package.json` - Adds purgecss as a dev dependency
+
 ## [2.5.3] - 2020-04-21
 ### Added
 - `_variables.scss` - add elections color palette 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@data-visuals/create",
-  "version": "2.5.3",
+  "version": "2.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@data-visuals/create",
-  "version": "2.5.3",
+  "version": "2.6.0",
   "description": "Create graphics and features the Data Visuals way.",
   "scripts": {
     "build:docs": "doctoc README.md --github",

--- a/templates/__common__/_package.json
+++ b/templates/__common__/_package.json
@@ -62,6 +62,7 @@
     "postcss": "^7.0.2",
     "postcss-flexbugs-fixes": "^4.1.0",
     "prettier": "^1.12.1",
+    "purgecss": "^2.1.2",
     "quaff": "^4.0.0",
     "rev-file": "^3.0.0",
     "sass": "^1.13.4",

--- a/templates/__common__/config/scripts/build.js
+++ b/templates/__common__/config/scripts/build.js
@@ -26,9 +26,9 @@ async function build() {
     parallel([api, images, styles]),
     copy,
     templates,
+    unusedCSS,
     rev,
     revReplace,
-    unusedCSS,
   ]);
 
   await runner();

--- a/templates/__common__/config/scripts/build.js
+++ b/templates/__common__/config/scripts/build.js
@@ -17,6 +17,7 @@ const revReplace = require('../tasks/rev-replace');
 const scripts = require('../tasks/scripts');
 const styles = require('../tasks/styles');
 const templates = require('../tasks/templates');
+const unusedCSS = require('../tasks/unused-css');
 
 async function build() {
   const runner = series([
@@ -27,6 +28,7 @@ async function build() {
     templates,
     rev,
     revReplace,
+    unusedCSS,
   ]);
 
   await runner();

--- a/templates/__common__/config/tasks/serve.js
+++ b/templates/__common__/config/tasks/serve.js
@@ -191,7 +191,7 @@ module.exports = () => {
         [
           path.join(paths.appTmpStyles, '/*.css'),
           path.join(paths.appTmp, '/**/*.html'),
-          path.join(paths.appSrc, 'scripts', 'components', '/**/*.js'),
+          path.join(paths.appSrc, 'scripts', '/**/*.js'),
         ],
         cleanUnusedCSS
       );

--- a/templates/__common__/config/tasks/serve.js
+++ b/templates/__common__/config/tasks/serve.js
@@ -13,6 +13,7 @@ const webpackDevMiddleware = require('webpack-dev-middleware');
 const paths = require('../paths');
 const styles = require('./styles');
 const templates = require('./templates');
+const unusedCSS = require('../tasks/unused-css');
 const {
   clearConsole,
   logErrorMessage,
@@ -59,6 +60,7 @@ module.exports = () => {
       let stylesError = null;
       let scriptsError = null;
       let scriptsWarning = null;
+      let unusedCSSError = null;
 
       console.log(colors.yellow('Starting initial serve...'));
 
@@ -101,6 +103,11 @@ module.exports = () => {
           onWarning('Scripts', scriptsWarning);
         }
 
+        if (unusedCSSError) {
+          hadError = true;
+          onError('Unused CSS check', unusedCSSError);
+        }
+
         if (!hadError) {
           console.log(colors.green('Project compiled successfully!'));
           printInstructions({ local, external });
@@ -141,6 +148,23 @@ module.exports = () => {
         logStatus();
       };
 
+      const cleanUnusedCSS = async () => {
+        try {
+          const paths = await unusedCSS();
+
+          // if browsersync is active, reload it
+          if (bs.active) {
+            paths.forEach(({ relativePath }) => bs.reload(relativePath));
+          }
+
+          unusedCSSError = null;
+        } catch (err) {
+          unusedCSSError = err;
+        }
+
+        logStatus();
+      };
+
       // initial compile of templates
       await compileTemplates();
 
@@ -158,6 +182,19 @@ module.exports = () => {
 
       // styles watching
       watch([path.join(paths.appStyles, '/**/*.scss')], compileStyles);
+
+      // initial CSS cleanup
+      await cleanUnusedCSS();
+
+      // watch template-related files
+      watch(
+        [
+          path.join(paths.appTmpStyles, '/*.css'),
+          path.join(paths.appTmp, '/**/*.html'),
+          path.join(paths.appSrc, 'scripts', 'components', '/**/*.js'),
+        ],
+        cleanUnusedCSS
+      );
 
       // scripts watching
       bundler.hooks.done.tap('done', stats => {

--- a/templates/__common__/config/tasks/unused-css.js
+++ b/templates/__common__/config/tasks/unused-css.js
@@ -1,0 +1,68 @@
+// native
+const path = require('path');
+
+// packages
+const fs = require('fs-extra');
+const { PurgeCSS } = require('purgecss');
+const CleanCSS = require('clean-css');
+
+// internal
+const paths = require('../paths');
+const { isProductionEnv } = require('../env');
+const { logErrorMessage, replaceExtension } = require('../utils');
+
+// output locations
+const stylesFolder = isProductionEnv ? paths.appDistStyles : paths.appTmpStyles;
+const htmlFolder = isProductionEnv ? paths.appDist : paths.appTmp;
+
+const parseCSS = async () => {
+  let result = [];
+  try {
+    // run purgeCSS
+    result = await new PurgeCSS().purge({
+      content: [
+        `${htmlFolder}/**/*.html`,
+        `${paths.appSrc}/scripts/components/**/*.js`,
+      ],
+      css: [`${stylesFolder}/*.css`],
+    });
+  } catch (error) {
+    logErrorMessage(error);
+  }
+  // [{css: parsedCSS, file: path/to/original/css-file}]
+  return result;
+};
+
+const writeCSS = async (result) => {
+  let { file, css } = result;
+
+  // get the path relative to its source location
+  const relativePath = replaceExtension(
+    path.relative(paths.appStyles, file),
+    '.css'
+  );
+
+  // get the raw file name
+  const filename = path.basename(file);
+
+  // create a new path for a nested min folder
+  const newPath = path.join(stylesFolder, 'min', filename);
+
+  // minify CSS
+  if (isProductionEnv) {
+    const cssCleaner = new CleanCSS({ returnPromise: true });
+    const { styles: minified } = await cssCleaner.minify(css);
+    css = minified;
+  }
+
+  // output optimized CSS file
+  await fs.outputFile(newPath, css);
+
+  return { inputPath: file, relativePath };
+};
+
+module.exports = async () => {
+  const strippedCSS = await parseCSS();
+
+  return await Promise.all(strippedCSS.map(writeCSS));
+};

--- a/templates/__common__/config/tasks/unused-css.js
+++ b/templates/__common__/config/tasks/unused-css.js
@@ -9,7 +9,7 @@ const CleanCSS = require('clean-css');
 // internal
 const paths = require('../paths');
 const { isProductionEnv } = require('../env');
-const { logErrorMessage, replaceExtension } = require('../utils');
+const { replaceExtension } = require('../utils');
 
 // output locations
 const stylesFolder = isProductionEnv ? paths.appDistStyles : paths.appTmpStyles;
@@ -26,14 +26,14 @@ const parseCSS = async () => {
       ],
       css: [`${stylesFolder}/*.css`],
     });
-  } catch (error) {
-    logErrorMessage(error);
+  } catch (err) {
+    throw err;
   }
   // [{css: parsedCSS, file: path/to/original/css-file}]
   return result;
 };
 
-const writeCSS = async (result) => {
+const writeCSS = async result => {
   let { file, css } = result;
 
   // get the path relative to its source location


### PR DESCRIPTION

### What do this do?
Adds a new task runner that parses CSS files for unused selectors.

This won't actually change anything; it just creates a new `styles/min/<filename>.css` file. The new file strips out extra CSS not referenced in the final compiled templates. To be clear, in order to use the new CSS, you'd need to deliberately choose to do so in your project [here](https://github.com/texastribune/data-visuals-create/blob/master/templates/feature/app/templates/base.html#L21).

### Why are we doing this?
The current CSS in `templates/__common__/app/styles/`  closely aligns with the needs of this kit and really doesn't benefit from this feature too much; however, if a more general CSS framework (like [our shared style lib](https://github.com/texastribune/queso-ui)) is used in a project, you could end up with superfluous helper classes that don't apply your project. The beauty of static sites is that we can optimize something like this during the build step.


### Added
- `templates/__common__/config/tasks/unused-css.js` - A step that looks at the CSS file linked in any .html file, parses that CSS, and writes new CSS based only on what the HTML needs through the magic of this wonderful tool, [purgecss](https://github.com/FullHuman/purgecss)

### Changed
- `templates/__common__/config/scripts/build.js` - This cleanup step will now run right after the HTML of the templates compile and before the file revving step
- `templates/__common__/config/tasks/serve.js` - New watchers added mostly in the build output folder to re-run the CSS cleanup step after the build
- `templates/__common__/_package.json` - Adds purgecss as a dev dependency

-----------------------------------------------------------------------------------------------

### Testing it:
- Clone a local version of `data-visuals-create`, checkout the branch `unused-css`, and run `your/path/to/data-visuals-create/bin/data-visuals-create feature my-test-feature`
1. Run `npm start`
2. Add any style to the bottom of main.scss. Then confirm the style takes and your page is updated. EX: Something you'd notice like:
```scss
.article-title {
  color: dodgerblue
}
```
And confirm that the headline is blue.

3. Now add some other selector that doesn't actually exist:
```scss
.some-rogue-class {
  color: rebeccapurple
}
```
4. First check the default CSS in `.tmp/styles/main.css`. You should find `.some-rogue-class` when you search for it. Now check `.tmp/styles/min/main.css`. You should not see that unused class referenced in this new CSS file.



###  Questions:
@mandicai - I wasn't sure how to test this feature for graphics, but I just pasted this build task into a coronavirus tracker table and it seemed to still work. Am I missing any weird catches for graphics?
