### PR TITLE
Update feed URLs to use new /articles/ API endpoint, update date/pub date layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Fixed
 
+## [2.7.1] - 2020-07-01
+### Added
+- `templates/__common__/app/styles/_typography.scss` - add styling for update date
+
+### Changed
+- `templates/feature/app/index.html` - add HTML to handle update date and pub date
+
+### Fixed
+- `templates/feature/app/scripts/utils/feeds.js` - switch v1 API urls to v2 API urls
+- `templates/feature/app/scripts/components/Story.js` - switch out properties to match v2 API urls 
+
 ## [2.7.0] - 2020-07-01
 ### Added
 - `templates/__common__/config/tasks/templates.js` - add renderStringWithNunjucks() filter to process data variables pulled in from a Google Doc #46

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,14 +12,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [2.7.1] - 2020-07-01
 ### Added
-- `templates/__common__/app/styles/_typography.scss` - add styling for update date
+- `templates/__common__/app/styles/_typography.scss` - add styling for update date #44
 
 ### Changed
-- `templates/feature/app/index.html` - add HTML to handle update date and pub date
+- `templates/feature/app/index.html` - add HTML to handle update date and pub date #44
 
 ### Fixed
-- `templates/feature/app/scripts/utils/feeds.js` - switch v1 API urls to v2 API urls
-- `templates/feature/app/scripts/components/Story.js` - switch out properties to match v2 API urls 
+- `templates/feature/app/scripts/utils/feeds.js` - switch v1 API urls to v2 API urls #6
+- `templates/feature/app/scripts/components/Story.js` - switch out properties to match v2 API urls #6
 
 ## [2.7.0] - 2020-07-01
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@data-visuals/create",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@data-visuals/create",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "description": "Create graphics and features the Data Visuals way.",
   "scripts": {
     "build:docs": "doctoc README.md --github",

--- a/templates/__common__/app/styles/_typography.scss
+++ b/templates/__common__/app/styles/_typography.scss
@@ -58,6 +58,26 @@
   }
 }
 
+.article-pub-update-date {
+  display: block;
+  margin-top: $gutter-quarter;
+
+  time {
+    @include mq($until: s) {
+      display: block;
+      margin-top: $gutter-quarter;
+    }
+
+    &:not(:first-child) {
+      margin-left: .625rem;
+
+      @include mq($until: s) {
+        margin-left: 0;
+      }
+    }
+  }
+}
+
 .article-shares {
   display: flex;
   flex-direction: row;

--- a/templates/feature/app/index.html
+++ b/templates/feature/app/index.html
@@ -22,9 +22,14 @@
       {%- endfor -%}
       </span>
       {% if context.update_date %}
-      <span class="article-pub-date">Updated: <time datetime="{{ context.update_date }}">{{ apFormatDate(context.update_date) }}</time></span>
+      <span class="article-pub-update-date">
+        <time datetime="{{ context.pub_date }}">Published: {{ apFormatDate(context.pub_date) }}</time>
+        <time datetime="{{ context.update_date }}">Updated: {{ apFormatDate(context.update_date) | widont}} </time>
+      </span>
       {% else %}
-      <span class="article-pub-date"><time datetime="{{ context.pub_date }}">{{ apFormatDate(context.pub_date) }}</time></span>
+      <span class="article-pub-date">
+        <time datetime="{{ context.pub_date }}">{{ apFormatDate(context.pub_date) }}</time>
+      </span>
       {% endif %}
     </p>
   </header>

--- a/templates/feature/app/scripts/components/Story.js
+++ b/templates/feature/app/scripts/components/Story.js
@@ -1,6 +1,7 @@
 import { h } from 'preact';
+import { apdate } from 'journalize';
 
-const Story = ({ headline, url, lead_art, readable_pub_date }) => {
+const Story = ({ headline, url, pub_date, sitewide_image }) => {
   return (
     <article class="story">
       <a
@@ -13,12 +14,15 @@ const Story = ({ headline, url, lead_art, readable_pub_date }) => {
       >
         <div class="story-media">
           <div class="story-art">
-            <img src={lead_art.thumbnails.letterbox} alt={headline} />
+            <img
+              src={sitewide_image.thumbnails.letterbox}
+              alt={sitewide_image.description}
+            />
           </div>
           <div class="story-text">
             <header class="story-header">
               <h4 class="story-headline">{headline}</h4>
-              <p class="story-byline">{readable_pub_date}</p>
+              <p class="story-byline">{apdate(new Date(pub_date))}</p>
             </header>
           </div>
         </div>

--- a/templates/feature/app/scripts/utils/feeds.js
+++ b/templates/feature/app/scripts/utils/feeds.js
@@ -1,6 +1,6 @@
 const TRENDING_STORIES_URL =
-  'https://www.texastribune.org/api/v1/content/most_viewed/?format=json&limit=5';
+  'https://www.texastribune.org/api/v2/articles/most_viewed/?format=json&limit=5';
 const BUILD_RELATED_CONTENT_URL = ({ gutenTag, numberOfStories = 4 }) =>
-  `https://www.texastribune.org/api/v1/content/?content_type=story,audio,video,pointer&tag=${gutenTag}&tag!=object-tribcast&fields=id,url,readable_pub_date,headline,short_summary,lead_art&limit=${numberOfStories}&format=json`;
+  `https://www.texastribune.org/api/v2/articles/?content_type=story,audio,video,pointer&tag=${gutenTag}&tag!=object-tribcast&fields=id,url,pub_date,headline,summary,sitewide_image&limit=${numberOfStories}&format=json`;
 
 export { BUILD_RELATED_CONTENT_URL, TRENDING_STORIES_URL };


### PR DESCRIPTION
### Added
- `templates/__common__/app/styles/_typography.scss` - add styling for update date #44

### Changed
- `templates/feature/app/index.html` - add HTML to handle update date and pub date #44

### Fixed
- `templates/feature/app/scripts/utils/feeds.js` - switch v1 API urls to v2 API urls #6
- `templates/feature/app/scripts/components/Story.js` - switch out properties to match v2 API urls #6

Closes #44 #6.