### PR TITLE
Add masthead title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Fixed
 
+## [3.1.0]
+### Added
+- `templates/feature/app/styles/components/_navbar.scss` - added masthead title to the nav bar component in the `index-queso.html` template
+- `templates/feature/app/templates/components/navbar.html` - added additional styling for the masthead title
+
 ## [3.0.0] - 2020-08-25
 ### Changed
 - `templates/feature/project.config.js` - change destination s3 bucket on deploy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Fixed
 
-## [3.1.0]
+## [3.1.0] - 2020-09-02
 ### Added
 - `templates/feature/app/styles/components/_navbar.scss` - added masthead title to the nav bar component in the `index-queso.html` template
 - `templates/feature/app/templates/components/navbar.html` - added additional styling for the masthead title
+
+### Fixed
+- `config/tasks/serve.js` - Adds an extra reload to refresh the page. When you first run npm run start there's a blip of no CSS while the CSS cleanup step runs. This will refresh again after that's finished so that console error referring to that missing CSS clears.
+- `config/tasks/unused-css.js` - Generalizes the gobbing pattern to capture more types of script files and in any folder. Previously CSS classes referenced in JS files weren't making it to the extra-minified CSS file, which is set up to only include classes used in the project.
 
 ## [3.0.0] - 2020-08-25
 ### Changed

--- a/templates/feature/app/styles/components/_navbar.scss
+++ b/templates/feature/app/styles/components/_navbar.scss
@@ -6,4 +6,9 @@
     padding-left: $size-b;
     padding-right: $size-b;
   }
+
+  &__logo {
+    width: 210px;
+    margin-right: $size-b;
+  }
 }

--- a/templates/feature/app/templates/components/navbar.html
+++ b/templates/feature/app/templates/components/navbar.html
@@ -1,9 +1,14 @@
 <header class="c-navbar c-navbar--dark">
   <div class="c-navbar__top l-align-center-x">
-    <a href="https://www.texastribune.org" class="c-navbar__logo l-align-center-self">
-      <span class="is-sr-only">The Texas Tribune</span>
-      {% include 'includes/logo.html' %}
-    </a>
+    <div class="c-navbar__branding l-align-center-children">
+      <a href="https://www.texastribune.org" class="c-navbar__logo">
+        <span class="is-sr-only">The Texas Tribune</span>
+        {% include 'includes/logo.html' %}
+      </a>
+      {% if context.masthead_title %}
+        <p class="has-text-white is-hidden-until-bp-m t-weight-bold t-links-underlined-hover-thin">{{ context.masthead_title }}</p>
+      {% endif %}
+    </div>
     <div class="c-navbar__content">
       <div class="c-navbar__items l-align-center-children">
          <a href="https://support.texastribune.org/" class="c-button c-button--standard t-uppercase">


### PR DESCRIPTION
### Added
- `templates/feature/app/styles/components/_navbar.scss` - added masthead title to the nav bar component in the `index-queso.html` template
- `templates/feature/app/templates/components/navbar.html` - added additional styling for the masthead title