### PR TITLE
Fix unused css task bugs

### DIFF
--- a/templates/__common__/config/tasks/serve.js
+++ b/templates/__common__/config/tasks/serve.js
@@ -185,6 +185,7 @@ module.exports = () => {
 
       // initial CSS cleanup
       await cleanUnusedCSS();
+      bs.reload();
 
       // watch template-related files
       watch(

--- a/templates/__common__/config/tasks/unused-css.js
+++ b/templates/__common__/config/tasks/unused-css.js
@@ -22,7 +22,7 @@ const parseCSS = async () => {
     result = await new PurgeCSS().purge({
       content: [
         `${htmlFolder}/**/*.html`,
-        `${paths.appSrc}/scripts/components/**/*.js`,
+        `${paths.appSrc}/**/*.{js,jsx,ts,tsx}`,
       ],
       css: [`${stylesFolder}/*.css`],
     });


### PR DESCRIPTION
### Changed
`config/tasks/serve.js` - Adds an extra reload to refresh the page. When you first run `npm run start` there's a blip of no CSS while the CSS cleanup step runs. This will refresh again after that's finished so that console error referring to that missing CSS clears.

`config/tasks/unused-css.js` - Generalizes the gobbing pattern to capture more types of script files and in any folder. Previously CSS classes referenced in JS files weren't making it to the extra-minified CSS file, which is set up to only include classes used in the project.
