### PR TITLE
Add graphic note and tags warning to parse step

### DIFF
--- a/templates/__common__/config/tasks/graphics-meta.js
+++ b/templates/__common__/config/tasks/graphics-meta.js
@@ -142,6 +142,7 @@ const parseGraphic = async (
   const context = { page, label };
   const title = await getText({ key: 'title', ...context });
   const description = await getText({ key: 'description', ...context });
+  const note = await getText({ key: 'note', ...context });
   const source = await getText({ key: 'source', ...context });
   let credits = await getText({ key: 'credit', ...context });
 
@@ -195,6 +196,7 @@ const parseGraphic = async (
       large: graphicPath + large,
       small: graphicPath + small,
     },
+    note,
     showInAppleNews,
     source,
     tags,

--- a/templates/__common__/config/tasks/graphics-meta.js
+++ b/templates/__common__/config/tasks/graphics-meta.js
@@ -28,6 +28,7 @@ const CHROME_INSTALL_PATH =
   '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
 
 const DESC_PLACEHOLDER = 'Description of graphic';
+const TAGS_PLACEHOLDER = ['subject-budget', 'subject-education'];
 
 const captureScreenshotOfElement = async (element, imagePath) => {
   await fs.ensureDir(path.dirname(imagePath));
@@ -84,6 +85,10 @@ const getText = async (params = { key: '', page: {}, label: '' }) => {
     );
   } catch {
     selectorFound = false;
+  }
+  // notes not required; no warning needed
+  if (key === 'note') {
+    return value;
   }
   if (!selectorFound) {
     console.log(colors.yellow(`Missing ${key} in ${label}`));
@@ -172,6 +177,15 @@ const parseGraphic = async (
     page,
     outputPath,
   });
+
+  // check if default tags are used
+  if (JSON.stringify(tags) === JSON.stringify(TAGS_PLACEHOLDER)) {
+    console.log(
+      colors.yellow(
+        `Placeholder tags still used in ${label}. See tags in project.config.js`
+      )
+    );
+  }
 
   //  check if appleNewsIgnore is specified
   let showInAppleNews = true;

--- a/templates/__common__/config/tasks/graphics-meta.js
+++ b/templates/__common__/config/tasks/graphics-meta.js
@@ -206,11 +206,11 @@ const parseGraphic = async (
     id,
     label,
     links,
+    note,
     previews: {
       large: graphicPath + large,
       small: graphicPath + small,
     },
-    note,
     showInAppleNews,
     source,
     tags,

--- a/templates/graphic/app/index.html
+++ b/templates/graphic/app/index.html
@@ -26,7 +26,7 @@
 
   {# data-source and data-credit are also used in the CMS #}
   <ul class="graphic-footer">
-    {% if context.note %}<li>Note: {{ context.note }}</li>{% endif %}
+    {% if context.note %}<li data-note>Note: {{ context.note }}</li>{% endif %}
     {% if context.source %}<li data-source>Source: {{ context.source }}</li>{% endif %}
     {% if context.credit %}<li data-credit>Credit: {{ context.credit }}</li>{% endif %}
   </ul>

--- a/templates/graphic/app/static.html
+++ b/templates/graphic/app/static.html
@@ -15,6 +15,7 @@
 {# if this is an ai2html graphic, fill out these variables #}
 {% set graphicTitle = context.headline %}
 {% set graphicDesc = 'Description of graphic' %}
+{% set graphicNote = context.credit %}
 {% set graphicSource = context.source %}
 {% set graphicCredit = context.credit %}
 

--- a/templates/graphic/app/static.html
+++ b/templates/graphic/app/static.html
@@ -31,7 +31,7 @@
 
   {# data-source and data-credit are also used in the CMS #}
   <ul class="graphic-footer">
-    {% if context.note %}<li>Note: {{ context.note }}</li>{% endif %}
+    {% if context.note %}<li data-note>Note: {{ context.note }}</li>{% endif %}
     {% if context.source %}<li data-source>Source: {{ context.source }}</li>{% endif %}
     {% if context.credit %}<li data-credit>Credit: {{ context.credit }}</li>{% endif %}
   </ul>

--- a/templates/graphic/app/static.html
+++ b/templates/graphic/app/static.html
@@ -15,7 +15,7 @@
 {# if this is an ai2html graphic, fill out these variables #}
 {% set graphicTitle = context.headline %}
 {% set graphicDesc = 'Description of graphic' %}
-{% set graphicNote = context.credit %}
+{% set graphicNote = context.note %}
 {% set graphicSource = context.source %}
 {% set graphicCredit = context.credit %}
 

--- a/templates/graphic/app/templates/base.html
+++ b/templates/graphic/app/templates/base.html
@@ -13,6 +13,9 @@
   {% if graphicDesc %}
     <meta name="tt-graphic-description" content="{{ graphicDesc }}" />
   {% endif %}
+  {% if graphicNote %}
+    <meta name="tt-graphic-note" content="{{ graphicNote }}" />
+  {% endif %}
   {% if graphicSource %}
     <meta name="tt-graphic-source" content="{{ graphicSource }}" />
   {% endif %}

--- a/templates/graphic/graphics-meta.md
+++ b/templates/graphic/graphics-meta.md
@@ -8,6 +8,7 @@ Graphics intended to be used as embeds in the CMS should have specific selectors
 | `[data-graphic]` | If present, the HTML of the page will be parsed for metadata and surfaced in the CMS | `<div class="app" data-graphic>` | N/A - If no `[data-graphic]` selector is found, the graphic won't output in manifest. |
 | `{{ graphicTitle }}` or `[data-title]` | The title of the graphic in the CMS | `{% set  graphicTitle = 'Some title' %}` or `<h1 class="graphic-title" data-title>Some title</h1>` | `title: string` |
 | `{{ graphicDesc }}` | The description of the graphic in the CMS. This will also be read by screenreaders in platforms like Apple News. | `{% set graphicDesc = 'This is a bar chart showing xyz' %}` | `description: string` |
+| `{{ graphicNote }}` or `[data-note]` | Note or disclaimer attached to the graphic. | `{% set graphicNote = 'Important disclaimer about this graphic.' %}` or `<li data-note>Note: Important disclaimer about this graphic.</li>` | `note: string` |
 | `{{ graphicSource }}` or `[data-source]` | The source of the graphic in the CMS | `{% set  graphicSource = 'TXDOT' %}` or `<li data-source>Source: TXDOT</li>` | `source: string` |
 | `{{ graphicCredit }}` or `[data-credit]` | The author names for the graphic in the CMS. | `{% set  graphicCredit = 'Trib Tribington, Super Cool Corgi' %}` or `<li data-credit>Trib Tribington and Super Cool Corgi</li>`  | `credits: array` |
 
@@ -22,7 +23,7 @@ Graphics intended to be used as embeds in the CMS should have specific selectors
 	{{ prose(context.prose, context, graphicData) }}
 	<div id="graphic" class="graphic"></div>
 	<ul class="graphic-footer">
-		<li>Note: {{ context.note }}</li>
+		<li data-note>Note: {{ context.note }}</li>
 		<li data-source>Source: {{ context.source }}</li>
 		<li data-credit>Credit: {{ context.credit }}</li>
 	</ul>
@@ -38,6 +39,7 @@ For Illustrator graphics, we typically set the title and other info in the Illus
 {% set context = data.text %}
 {% set graphicTitle = 'Headline from AI graphic' %}
 {% set graphicDesc = 'Description of graphic' %}
+{% set graphicNote = 'Note from AI graphic' %}
 {% set graphicSource = 'Source from AI graphic' %}
 {% set graphicCredit = 'Credit from AI graphic' %}
 {% block  content %}
@@ -47,7 +49,7 @@ For Illustrator graphics, we typically set the title and other info in the Illus
 	{% set ai2html = "border-map-full" %}
 	{% include "ai2html-output/" + ai2html + ".html" %}
 	<ul class="graphic-footer">
-		<li>Note: {{ context.note }}</li>
+		<li data-note>Note: {{ context.note }}</li>
 		<li data-source>Source: {{ context.source }}</li>
 		<li data-credit>Credit: {{ context.credit }}</li>
 	</ul>
@@ -87,6 +89,7 @@ Project config keys output in `manifest.json`
         "isCTA": true
       }
     ],
+    "note": "Note: Texas Department of State Health Services was missing data last year.",
     "previews": {
       "large": "https://graphics.texastribune.org/graphics/new-test-2-2021-02/static/preview-large.png",
       "small": "https://graphics.texastribune.org/graphics/new-test-2-2021-02/static/preview-small.png"


### PR DESCRIPTION
### Changed
- `templates/__common__/config/tasks/graphics-meta.js` - Adds a graphic note to the manifest file. Also now logs a warning to the terminal if you don't update the tags in the project config.
- ` templates/graphic/app/index.html`, 
`templates/graphic/app/static.html`, 
` templates/graphic/app/templates/base.html` - Adds all the proper template attributes to surface notes to the parsing task
` templates/graphic/graphics-meta.md` - Documents the new key

## Test steps:

1. Check out `graphics-meta-fixes` and run `your/path/to/data-visuals-create/bin/data-visuals-create graphic my-test-graphic`
2. In that new project, add some sample HTML to the index.html. Feel free to use something from an old project or just this [test HTML](https://gist.github.com/ashley-hebler/44632a2c7eef5064b4d2b602dd100b97) I've been using.
3. Run `npm run serve` to preview the graphic.
4. Run `npm run build`
5. Confirm you see `note:` appearing in the manifest.json output now.
6. Also confirm you see the new warning about the default tags and the language makes sense to you.
