### PR TITLE
Metadata to sheet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Fixed
 
+## [6.0.0] - 2021-08-12
+### Changed
+- `templates/__common__/utils/deployment/update-log-sheet.js` - write more metadata from `manifest.json` to the log sheet
+- `templates/__common__/utils/deployment/update-readme.js` - add bullets to links pasted to README
+- `templates/graphic/app/index.html`, `templates/graphic/app/static.html` - get alt-text from our Google Doc
+
 ## [5.0.1] - 2021-08-05
 ## Fixed
 - `_common_/app/styles/_functions.scss`, `_common_/app/styles/utilities/_embed.scss` - replace `/` with `math.div` to address Dart Sass warnings #94

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@data-visuals/create",
-  "version": "5.0.1",
+  "version": "6.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@data-visuals/create",
-  "version": "5.0.1",
+  "version": "6.0.0",
   "description": "Create graphics and features the Data Visuals way.",
   "scripts": {
     "build:docs": "doctoc README.md --github",

--- a/templates/__common__/utils/deployment/deploy.js
+++ b/templates/__common__/utils/deployment/deploy.js
@@ -24,7 +24,7 @@ s3.uploadFiles(paths.appDist, {
 
   await write(mainPath);
   await updateReadMe(paths, mainPath, config.files);
-  await updateLogSheet(mainPath, config);
+  await updateLogSheet(config);
 
   console.log(`
 Upload of ${colors.yellow(numFiles)} file${numFiles === 1 ? '' : 's'} complete.
@@ -32,7 +32,9 @@ Upload of ${colors.yellow(numFiles)} file${numFiles === 1 ? '' : 's'} complete.
 Good work! The primary page of this project can be found at:
 ${colors.blue.underline(mainPath)} (This has been copied to your clipboard.)
 
-Did you run ${colors.yellow(`npm run data:fetch`)} before deploying to get the latest data?`);
+Did you run ${colors.yellow(
+    `npm run data:fetch`
+  )} before deploying to get the latest data?`);
 
   if (projectType === 'feature') {
     console.log(`

--- a/templates/__common__/utils/deployment/deploy.js
+++ b/templates/__common__/utils/deployment/deploy.js
@@ -24,7 +24,7 @@ s3.uploadFiles(paths.appDist, {
 
   await write(mainPath);
   await updateReadMe(paths, mainPath, config.files);
-  await updateLogSheet(config);
+  await updateLogSheet(mainPath, config);
 
   console.log(`
 Upload of ${colors.yellow(numFiles)} file${numFiles === 1 ? '' : 's'} complete.

--- a/templates/__common__/utils/deployment/update-log-sheet.js
+++ b/templates/__common__/utils/deployment/update-log-sheet.js
@@ -19,6 +19,7 @@ function getFileLink(files, type) {
   } else return '';
 }
 
+// fetch latest data and write new data to sheet
 async function writeToSheet(
   sheets,
   spreadsheetId,
@@ -71,7 +72,7 @@ async function writeToSheet(
 }
 
 // update log of past data visuals works with project info
-let updateLogSheet = async config => {
+let updateLogSheet = async (mainPath, config) => {
   // read manifest file, which has metadata about the project
   const manifest = fs.readFileSync(`${paths.appDist}/manifest.json`, 'utf8');
 
@@ -98,33 +99,43 @@ let updateLogSheet = async config => {
     }
 
     // loop through metadata JSON
-    for (const metadata of manifestJSON) {
-      let metadataInput = [
-        [
-          metadata.id,
-          metadata.graphicURL,
-          metadata.graphicPath,
-          metadata.title,
-          metadata.caption,
-          metadata.description,
-          `${metadata.createYear}-${metadata.createMonth}`,
-          metadata.lastBuildTime,
-          metadata.note,
-          metadata.source,
-          metadata.credits.join(', '),
-          metadata.tags.join(', '),
-          getFileLink(config.files, 'sheet'),
-          getFileLink(config.files, 'doc'),
-        ],
-      ];
-
+    if (manifestJSON.length == 0) {
       await writeToSheet(
         sheets,
         spreadsheetId,
         sheetName,
-        metadata,
-        metadataInput
+        { id: config.id, graphicURL: mainPath },
+        [[config.id, mainPath]]
       );
+    } else {
+      for (const metadata of manifestJSON) {
+        let metadataInput = [
+          [
+            metadata.id,
+            metadata.graphicURL,
+            metadata.graphicPath,
+            metadata.title,
+            metadata.caption,
+            metadata.description,
+            `${metadata.createYear}-${metadata.createMonth}`,
+            metadata.lastBuildTime,
+            metadata.note,
+            metadata.source,
+            metadata.credits.join(', '),
+            metadata.tags.join(', '),
+            getFileLink(config.files, 'sheet'),
+            getFileLink(config.files, 'doc'),
+          ],
+        ];
+
+        await writeToSheet(
+          sheets,
+          spreadsheetId,
+          sheetName,
+          metadata,
+          metadataInput
+        );
+      }
     }
   }
 };

--- a/templates/__common__/utils/deployment/update-log-sheet.js
+++ b/templates/__common__/utils/deployment/update-log-sheet.js
@@ -125,6 +125,8 @@ let updateLogSheet = async (mainPath, config) => {
             metadata.tags.join(', '),
             getFileLink(config.files, 'sheet'),
             getFileLink(config.files, 'doc'),
+            metadata.previews.large,
+            metadata.previews.small
           ],
         ];
 

--- a/templates/__common__/utils/deployment/update-log-sheet.js
+++ b/templates/__common__/utils/deployment/update-log-sheet.js
@@ -126,7 +126,7 @@ let updateLogSheet = async (mainPath, config) => {
             getFileLink(config.files, 'sheet'),
             getFileLink(config.files, 'doc'),
             metadata.previews.large,
-            metadata.previews.small
+            metadata.previews.small,
           ],
         ];
 

--- a/templates/__common__/utils/deployment/update-log-sheet.js
+++ b/templates/__common__/utils/deployment/update-log-sheet.js
@@ -26,6 +26,8 @@ let updateLogSheet = async config => {
 
   if (manifest) {
     const manifestJSON = JSON.parse(manifest); // convert metadata to JSON object
+    
+    // set up auth to connect to Google
     const auth = await getAuth();
     const sheets = google.sheets({
       version: 'v4',

--- a/templates/__common__/utils/deployment/update-readme.js
+++ b/templates/__common__/utils/deployment/update-readme.js
@@ -19,10 +19,10 @@ let updateReadMe = async (paths, mainPath, files) => {
   // add project link
   if (readMe[startLine] != '') {
     // if link exists, update it
-    readMe[startLine] = `[Link to your project](${mainPath})`;
+    readMe[startLine] = `-[Link to your project](${mainPath})`;
   } else {
     // insert project link
-    readMe.splice(startLine, 0, `[Link to your project](${mainPath})`);
+    readMe.splice(startLine, 0, `-[Link to your project](${mainPath})`);
   }
 
   // add data link(s)
@@ -33,7 +33,7 @@ let updateReadMe = async (paths, mainPath, files) => {
 
     // if link exists, update it
     if (readMe[i] != '') {
-      readMe[i] = `[Link to your ${
+      readMe[i] = `-[Link to your ${
         files[i - (startLine + 1)].type
       }](${dataLink})`;
     } else {
@@ -41,7 +41,7 @@ let updateReadMe = async (paths, mainPath, files) => {
       readMe.splice(
         i,
         0,
-        `[Link to your ${files[i - (startLine + 1)].type}](${dataLink})`
+        `-[Link to your ${files[i - (startLine + 1)].type}](${dataLink})`
       );
     }
   }

--- a/templates/graphic/app/index.html
+++ b/templates/graphic/app/index.html
@@ -12,7 +12,7 @@
 {% set graphicData = data.data %}
 
 {# graphicDesc is used by the CMS for accessibility #}
-{% set graphicDesc = '' %}
+{% set graphicDesc = context.description %}
 
 {% block content %}
 {# data-graphic signifies that this can be embedded in the CMS #}

--- a/templates/graphic/app/static.html
+++ b/templates/graphic/app/static.html
@@ -16,7 +16,7 @@
 {% set graphicTitle = context.headline %}
 {% set graphicCaption = '' %}
 {# graphicDesc is used by the CMS for accessibility #}
-{% set graphicDesc = '' %}
+{% set graphicDesc = context.description %}
 {% set graphicNote = context.note %}
 {% set graphicSource = context.source %}
 {% set graphicCredit = context.credit %}


### PR DESCRIPTION
**What it does:**
- Gets metadata from `manifest.json` and writes it to [this sheet](https://docs.google.com/spreadsheets/d/18f3xmv1_pwgw7vPvBaX9fnDvH2FlQAuHzmB7F_LH4_I/edit#gid=773081895).
- Currently, the code loops through `manifest.json` and writes data for each graphic in that file to the sheet. It writes the project ID and the main path of the project if the manifest is an empty array []. 
- It will not work if `manifest.json` does not exist. It will not work if metadata is generated, but it's missing any of the fields pasted into the sheet.

**Things to consider:**
- When looping over the manifest metadata, we grab the latest values from the Google Sheet and append a new row after the last row. I was running into a situation previously when the code was grabbing the latest values in the next iteration before the previous graphic's metadata was pasted in, which led to the the last graphic's metadata overriding the first graphic's metadata. I added an `await` before the function fetching the latest data from the Google Sheet, which seems to fix this problem, but I'll need to test this again.

**To test:**
When we have metadata:
1) Go to `data-visuals-create` and checkout the branch `metadata-to-sheet`.
2) Navigate to whichever folder you generate graphics in and run `/path/to/data-visuals-create/bin/data-visuals-create graphic test`.
3) Run `npm run data:fetch`. That will get some sample metadata.
4) Run `npm run deploy`. You should see two entries, one for `index.html` and one for `static.html` in the [metadata spreadsheet](https://docs.google.com/spreadsheets/d/18f3xmv1_pwgw7vPvBaX9fnDvH2FlQAuHzmB7F_LH4_I/edit#gid=773081895).

When we don't have metadata:
1) Go to the `data/` folder in the test graphic. Delete `text.json`, which will remove any test metadata that we pulled in.
2) Delete all entries in the spreadsheet.
3) Run `npm run deploy`.  You should see an entry with the project ID and the main path in the spreadsheet. We write this when no metadata is generated, so we don't lose track of graphics.

^ Repeat the steps for "when we don't have metadata" for a feature (run `/path/to/data-visuals-create/bin/data-visuals-create feature test`). We may have to tweak this a bit for features — currently we check for the project ID and the URL in the sheet for looking for the corresponding row, but for features we alternate between `capybara-test` and `apps` in the project URL.

**Next steps:**
1) Figure out how to sync this up with our datawrapper graphics. Datawrapper might have its own API that we can ping to get a list of our graphics and the corresponding links.