### PR TITLE
Replace `/` with `math.div`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Fixed
 
-## [5.0.1]
+## [5.0.1] - 2021-08-05
 ## Fixed
 - `_common_/app/styles/_functions.scss`, `_common_/app/styles/utilities/_embed.scss` - replace `/` with `math.div` to address Dart Sass warnings #94
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Fixed
 
+## [5.0.1]
+## Fixed
+- `_common_/app/styles/_functions.scss`, `_common_/app/styles/utilities/_embed.scss` - replace `/` with `math.div` to address Dart Sass warnings #94
+
 ## [5.0.0] - 2021-08-04
 ### Changed
 - `package.json`, `package-lock.json` - bump `assets-webpack-plugin`, `googleapis`, `imagemin`, `imagemin-gifsicle`, `imagemin-jpegtran`, `imagemin-optipng` packages (major version bumps for `imagemin-gifsicle`, `imagemin-jpegtran`, `imagemin-optipng` require Node.js v10)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@data-visuals/create",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@data-visuals/create",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "Create graphics and features the Data Visuals way.",
   "scripts": {
     "build:docs": "doctoc README.md --github",

--- a/templates/__common__/app/styles/_functions.scss
+++ b/templates/__common__/app/styles/_functions.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 // to-rem
 // Converts a value to rem based on the base font size
 @function to-rem($val, $base: $font-size-base) {
@@ -12,12 +14,12 @@
 
   // strip off the px if needed
   @if $val-unit == 'px' {
-    $val: $val / 1px;
+    $val: math.div($val, 1px);
   }
 
   // Calculate rem if units for $val is not rem
   @if $val-unit != 'rem' {
-    $val: ($val / $base) * 1rem;
+    $val: (math.div($val, $base)) * 1rem;
   }
 
   // 0rem into 0
@@ -42,12 +44,12 @@
 
   // strip off the px if needed
   @if $val-unit == 'px' {
-    $val: $val / 1px;
+    $val: math.div($val, 1px);
   }
 
   // Calculate em if units for $val is not em
   @if $val-unit != 'em' {
-    $val: ($val / $base) * 1em;
+    $val: (math.div($val, $base)) * 1em;
   }
 
   // 0em into 0
@@ -64,7 +66,7 @@
   $g: green($color);
   $b: blue($color);
 
-  $yiq: (($r * 299) + ($g * 587) + ($b * 114)) / 1000;
+  $yiq: math.div((($r * 299) + ($g * 587) + ($b * 114)), 1000);
 
   @if ($yiq >= $yiq-contrasted-threshold) {
     @return $yiq-text-dark;

--- a/templates/__common__/app/styles/utilities/_embed.scss
+++ b/templates/__common__/app/styles/utilities/_embed.scss
@@ -1,3 +1,5 @@
+@use "sass:math";
+
 .embed-responsive {
   display: block;
   overflow: hidden;
@@ -27,24 +29,24 @@
 
 .embed-responsive--21x9 {
   &::before {
-    padding-top: percentage(9 / 21);
+    padding-top: percentage(math.div(9, 21));
   }
 }
 
 .embed-responsive--16x9 {
   &::before {
-    padding-top: percentage(9 / 16);
+    padding-top: percentage(math.div(9, 16));
   }
 }
 
 .embed-responsive--4x3 {
   &::before {
-    padding-top: percentage(3 / 4);
+    padding-top: percentage(math.div(3, 4));
   }
 }
 
 .embed-responsive--1x1 {
   &::before {
-    padding-top: percentage(1 / 1);
+    padding-top: percentage(math.div(1, 1));
   }
 }


### PR DESCRIPTION
## [5.0.1]
## Fixed
- `_common_/app/styles/_functions.scss`, `_common_/app/styles/utilities/_embed.scss` - replace `/` with `math.div` to address Dart Sass warnings #94