### PR TITLE
Get graphic tags from Google Doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Fixed
 
+## [7.1.0] - 2021-11-16
+### Changed
+- `templates/graphic/app/index.html`, `templates/graphic/app/static.html` - set tags fetched from the Google Doc as a variable
+- `templates/graphic/app/templates/base.html` - grab tags and add as a metadata attribute on the graphic, metadata parser will fetch tags from here
+- `templates/graphic/project.config.js` - remove `tags` attribute, add `graphicsIgnore` attribute to `parserOptions`
+- `templates/__common__/config/tasks/graphics-meta.js` - change parser to grab metadata from the templates and use the list of graphics to ignore from the config file to ignore certain filepaths when parsing
+
 ## [7.0.0] - 2021-11-10 
 ### Changed
 - `templates/graphic/app/index.html` - convert `index.html` to a landing page with instructions for how to create graphics from the templates

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@data-visuals/create",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@data-visuals/create",
-      "version": "7.0.0",
+      "version": "7.1.0",
       "license": "MIT",
       "dependencies": {
         "ansi-colors": "^3.2.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@data-visuals/create",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Create graphics and features the Data Visuals way.",
   "scripts": {
     "build:docs": "doctoc README.md --github",

--- a/templates/__common__/config/tasks/graphics-meta.js
+++ b/templates/__common__/config/tasks/graphics-meta.js
@@ -122,7 +122,6 @@ const parseGraphic = async (
     lastBuildTime,
     folder,
     id,
-    tags,
     parserOptions,
   } = config;
 
@@ -157,6 +156,7 @@ const parseGraphic = async (
   const altText = await getText({ key: 'alt-text', page });
   const note = await getText({ key: 'note', page });
   const source = await getText({ key: 'source', page });
+  const tags = await (await getText({ key: 'tags', page })).split(',');
   let credits = await getText({ key: 'credit', page });
 
   // ignore graphics with no title

--- a/templates/__common__/config/tasks/graphics-meta.js
+++ b/templates/__common__/config/tasks/graphics-meta.js
@@ -228,11 +228,16 @@ const parseGraphic = async (
 };
 
 module.exports = async localURL => {
+  const {
+    parserOptions,
+  } = config;
+
   // find all html pages in project
   const pages = await glob('**/*.html', {
     absolute: true,
     cwd: './.tmp',
     recursive: true,
+    ignore: parserOptions.graphicsIgnore,
   });
 
   // spin up headless browser using local chrome

--- a/templates/graphic/app/index.html
+++ b/templates/graphic/app/index.html
@@ -2,6 +2,21 @@
 {% extends 'base.html' %}
 {% from 'macros/prose.html' import prose %}
 
+{# set pack that provides JS #}
+{% set jsPackName = 'main' %}
+
+{# data.text --> data/text.json #}
+{% set context = data.text %}
+
+{# data.data --> data/data.json #}
+{% set graphicData = data.data %}
+
+{# graphicAltText is used by the CMS for accessibility #}
+{% set graphicAltText = context.alttext %}
+
+{# graphics will be surfaced in the graphics plugin under these tags #}
+{% set graphicTags = context.guten_tags %}
+
 {% block content %}
 <div class="app">
   <h1 class="article-subheader">Welcome to The Texas Tribune's data visuals graphics kit!</h1>

--- a/templates/graphic/app/templates/base.html
+++ b/templates/graphic/app/templates/base.html
@@ -25,6 +25,9 @@
   {% if graphicCredit %}
     <meta name="tt-graphic-credit" content="{{ graphicCredit }}" />
   {% endif %}
+  {% if graphicTags %}
+    <meta name="tt-graphic-tags" content="{{ graphicTags or 'subject-politics' }}" />
+  {% endif %}
 
   <link rel="dns-prefetch" href="https://www.google-analytics.com">
   <link rel="dns-prefetch" href="https://fonts.googleapis.com">

--- a/templates/graphic/app/templates/graphic-static.html
+++ b/templates/graphic/app/templates/graphic-static.html
@@ -20,6 +20,8 @@
 {% set graphicNote = context.note %}
 {% set graphicSource = context.source %}
 {% set graphicCredit = context.credit %}
+{# graphics will be surfaced in the graphics plugin under these tags #}
+{% set graphicTags = context.guten_tags %}
 
 {% block content %}
 {# data-graphic signifies that this can be embedded in the CMS #}

--- a/templates/graphic/project.config.js
+++ b/templates/graphic/project.config.js
@@ -65,13 +65,6 @@ module.exports = {
     },
   ],
   /**
-   * Tags that will be plugged in via the graphics plugin.
-   * This an array of each tag's slug, not the tag names.
-   * Refer to https://www.texastribune.org/admin/guten_tags/tag/ for our guten tag slugs.
-   * YOU CAN CHANGE THESE.
-   */
-  tags: ['subject-politics'],
-  /**
    * The dataMutators option makes it possible to modify what's returned by
    * the data fetchers. This is a good place to restructure the raw data, or
    * to do joins with other data you may have.

--- a/templates/graphic/project.config.js
+++ b/templates/graphic/project.config.js
@@ -129,6 +129,7 @@ module.exports = {
    *
    */
   parserOptions: {
+    graphicsIgnore: [],
     appleNewsIgnore: [],
   },
 };


### PR DESCRIPTION
Right now, we add tags for our graphics (which the graphics plugin will use to surface graphics when a tag is searched) in `project.config.js`. Most of our metadata is fetched through our [Google Doc text template](https://docs.google.com/document/d/1BKQy7bsteC7Od5Jgzt_PX8KRe0pD2Ba1LXEj02uWf4I/edit), after the text is processed by ArchieML on `npm run data:fetch`. 

This PR changes the kit so that graphics get tags from the Google Doc used in that repository, instead of the config file. Users will add relevant tags for their graphics in whatever Google Doc they have linked to the graphic. The thought is that if the metadata we add/edit is centralized in one place, it will be easier to remember to add it. Tags are an important piece of the graphics plugin functioning properly.

This PR also adds an additional attribute in the config file that allows us to add graphics we don't want to show up in the graphics plugin. I couldn't figure out how to add it to the Google Doc, because then I'd have to include the list of graphics to ignore parsing in the graphic templates themselves. That doesn't make sense — you can't get information about what to ignore from a template you're potentially trying to ignore.

### Changed
- `templates/graphic/app/index.html`, `templates/graphic/app/static.html` - set tags fetched from the Google Doc as a variable
- `templates/graphic/app/templates/base.html` - grab tags and add as a metadata attribute on the graphic, metadata parser will fetch tags from here
- `templates/graphic/project.config.js` - remove `tags` attribute, add `graphicsIgnore` attribute to `parserOptions`
- `templates/__common__/config/tasks/graphics-meta.js` - change parser to grab metadata from the templates and use the list of graphics to ignore from the config file to ignore certain filepaths when parsing

### To test
1) Go to `data-visuals-create` and checkout the branch `tags`.
2) Navigate to whichever folder you generate graphics in and run `/path/to/data-visuals-create/bin/data-visuals-create graphic tags-test`.
3) Navigate to inside your new test graphic. Run `npm run data:fetch`. That will get some sample metadata. Right now, we have the tags `subject-coronavirus` and `subject-health-care` as the default tags in the [graphic ArchieML template](https://docs.google.com/document/d/1BKQy7bsteC7Od5Jgzt_PX8KRe0pD2Ba1LXEj02uWf4I/edit).
4) Run `npm run build`. You should see a `dist/` folder. Open up the file `manifest.json` in that folder and look at the graphic metadata that was generated. (I liked to right click in VSCode and hit "Format Document" to make it prettier.)
5) Check that the tags for the graphics are `subject-coronavirus` and `subject-health-care`.
6) Play around by swapping out those tags for other ones and repeating the steps above ^. Just make sure you change back the tags in the doc to the original ones!