### PR TITLE
Remove old messages after deploying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Fixed
 
+## [7.2.2] - 2022-04-20
+-  `templates/__common__/utils/deployment/deploy.js` - remove instructions for embedding raw plugins in post-deploy message
+
 ## [7.2.1] - 2022-04-20
 ### Changed
 - `templates/__common__/_package.json` - update packages to address vulnerabilities

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@data-visuals/create",
-  "version": "7.2.1",
+  "version": "7.2.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@data-visuals/create",
-      "version": "7.2.1",
+      "version": "7.2.2",
       "license": "MIT",
       "dependencies": {
         "ansi-colors": "^3.2.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@data-visuals/create",
-  "version": "7.2.1",
+  "version": "7.2.2",
   "description": "Create graphics and features the Data Visuals way.",
   "scripts": {
     "build:docs": "doctoc README.md --github",

--- a/templates/__common__/utils/deployment/deploy.js
+++ b/templates/__common__/utils/deployment/deploy.js
@@ -35,31 +35,4 @@ ${colors.blue.underline(mainPath)} (This has been copied to your clipboard.)
 Did you run ${colors.yellow(
     `npm run data:fetch`
   )} before deploying to get the latest data?`);
-
-  if (projectType === 'feature') {
-    console.log(`
-If you are deploying a feature, check Facebook/Twitter/other social platforms to make sure the 
-share image shows up.`);
-  }
-
-  if (projectType === 'graphic') {
-    console.log(`
-If you are deploying a graphic in a CMS story, there are a few steps. First,
-add this in the Content section of the Raw Plugin:
-${colors.yellow(
-  `<div class="dv201808-graphic dv201808-graphic--centered dv201808-graphic--centered-narrow" data-frame-src="${mainPath}" data-frame-sandbox="allow-scripts allow-same-origin allow-top-navigation-by-user-activation allow-top-navigation"></div>`
-)}`);
-
-    console.log(`
-Next, add the style code snippet found in ${colors.yellow(
-      'app/styles/raw-plugin-styles.html'
-    )} to the CSS content section of the Raw Plugin`);
-
-    console.log(`
-Then, add this line to the JavaScript content section of the Raw Plugin:
-${colors.yellow(
-  '<script src="https://cdn.texastribune.org/lib/@newswire/frames@0.3.1/index.umd.js"></script>'
-)}
-${colors.yellow('<script>newswireFrames.autoInitFrames();</script>')}`);
-  }
 });


### PR DESCRIPTION
## [7.2.2] - 2022-04-20
-  `templates/__common__/utils/deployment/deploy.js` - remove instructions for embedding raw plugins in post-deploy message