### PR TITLE
Only add credits meta when the graphicsCredit variable is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Fixed
 
+## [7.2.3] - 2022-04-20
+### Changed
+- `templates/feature/app/templates/base-graphic.html` - only add a meta tag with `graphicCredit` if the variable is set in the HTML template. If `graphicCredit` is set in the HTML, it will take precedent over the credit set in the `data-credit` tag in the generated metadata.
+- `templates/graphic/app/templates/base.html` - Ditto here, but for graphics attached to features.
+
 ## [7.2.2] - 2022-04-20
 ### Changed
 -  `templates/__common__/utils/deployment/deploy.js` - remove instructions for embedding raw plugins in post-deploy message

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@data-visuals/create",
-  "version": "7.2.2",
+  "version": "7.2.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@data-visuals/create",
-      "version": "7.2.2",
+      "version": "7.2.3",
       "license": "MIT",
       "dependencies": {
         "ansi-colors": "^3.2.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@data-visuals/create",
-  "version": "7.2.2",
+  "version": "7.2.3",
   "description": "Create graphics and features the Data Visuals way.",
   "scripts": {
     "build:docs": "doctoc README.md --github",

--- a/templates/feature/app/templates/base-graphic.html
+++ b/templates/feature/app/templates/base-graphic.html
@@ -22,8 +22,9 @@
   {% if graphicSource %}
     <meta name="tt-graphic-source" content="{{ graphicSource }}" />
   {% endif %}
-
-  <meta name="tt-graphic-credit" content="{{ graphicCredit or 'Texas Tribune Staff'}}" />
+  {% if graphicCredit %}
+    <meta name="tt-graphic-credit" content="{{ graphicCredit }}" />
+  {% endif %}
   <meta name="tt-graphic-tags" content="{{ graphicTags or ['subject-politics'] }}" />
 
   <link rel="dns-prefetch" href="https://www.google-analytics.com">

--- a/templates/graphic/app/templates/base.html
+++ b/templates/graphic/app/templates/base.html
@@ -22,8 +22,9 @@
   {% if graphicSource %}
     <meta name="tt-graphic-source" content="{{ graphicSource }}" />
   {% endif %}
-
-  <meta name="tt-graphic-credit" content="{{ graphicCredit or 'Texas Tribune Staff'}}" />
+  {% if graphicCredit %}
+    <meta name="tt-graphic-credit" content="{{ graphicCredit }}" />
+  {% endif %}
   <meta name="tt-graphic-tags" content="{{ graphicTags or ['subject-politics'] }}" />
 
   <link rel="dns-prefetch" href="https://www.google-analytics.com">


### PR DESCRIPTION
## [7.2.3] - 2022-04-20
### Changed
- `templates/feature/app/templates/base-graphic.html` - only add a meta tag with `graphicCredit` if the variable is set in the HTML template. If `graphicCredit` is set in the HTML, it will take precedent over the credit set in the `data-credit` tag in the generated metadata.
- `templates/graphic/app/templates/base.html` - Ditto here, but for graphics attached to features.