### PR TITLE
More small fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-## [7.4.0] - 2022-06-22
+## [7.4.0] - 2022-06-06
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-## [7.4.0] - 2022-04-20
+## [7.4.0] - 2022-06-22
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+## [7.4.0] - 2022-04-20
+
+### Changed
+
+- `templates/__common__/config/tasks/graphics-meta.js` - make sources metadata an array
+- `templates/feature/app/scripts/utils/ad-loader.js` - make ad square if ad has class `dv-gpt-ad-square`
+- `templates/feature/app/templates/embed.html`, `templates/graphic/app/templates/graphic-static.html` - wrap credit, note and source metadata in `data-` tags so "Credit:", "Note:" and "Source:" don't appear in metadata
+- `templates/graphic/app/templates/graphic.html` - add default graphic headline and wrap credit, note and source metadata in `data-` tags
+
 ## [7.3.0] - 2022-04-20
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@data-visuals/create",
-  "version": "7.3.0",
+  "version": "7.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@data-visuals/create",
-      "version": "7.3.0",
+      "version": "7.4.0",
       "license": "MIT",
       "dependencies": {
         "ansi-colors": "^3.2.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@data-visuals/create",
-  "version": "7.3.0",
+  "version": "7.4.0",
   "description": "Create graphics and features the Data Visuals way.",
   "scripts": {
     "build:docs": "doctoc README.md --github",

--- a/templates/__common__/config/tasks/graphics-meta.js
+++ b/templates/__common__/config/tasks/graphics-meta.js
@@ -180,7 +180,7 @@ const parseGraphic = async (
     const caption = await getText({ key: 'caption', page });
     const altText = await getText({ key: 'alt-text', page });
     const note = await getText({ key: 'note', page });
-    const source = await getText({ key: 'source', page });
+    let source = await getText({ key: 'source', page });
 
     // create array from source
     if (source.length > 0) {

--- a/templates/__common__/config/tasks/graphics-meta.js
+++ b/templates/__common__/config/tasks/graphics-meta.js
@@ -182,6 +182,14 @@ const parseGraphic = async (
     const note = await getText({ key: 'note', page });
     const source = await getText({ key: 'source', page });
 
+    // create array from source
+    if (source.length > 0) {
+      // separate by commas or and
+      source = source.split(/, *| and */g);
+    } else {
+      source = [];
+    }
+
     const links = await page.$$eval('a', links =>
       links.map(link => {
         return {

--- a/templates/__common__/config/tasks/graphics-meta.js
+++ b/templates/__common__/config/tasks/graphics-meta.js
@@ -170,7 +170,7 @@ const parseGraphic = async (
   // create array from credits
   if (credits.length > 0) {
     // separate by commas or and
-    credits = credits.replace('Credit: ', '').split(/, *| and */g);
+    credits = credits.split(/, *| and */g);
   } else {
     credits = [];
   }

--- a/templates/feature/app/scripts/utils/ad-loader.js
+++ b/templates/feature/app/scripts/utils/ad-loader.js
@@ -99,9 +99,13 @@ class AdLoader {
         adElementId
       );
 
-      // overwrites the default fixed size set above
-      // if the ad is a banner ad
-      gptAdUnit.defineSizeMapping(banner);
+      // make ad square if it includes the `dv-gpt-ad-square` class
+      if (attributes.class.includes('dv-gpt-ad-square')) {
+        gptAdUnit.defineSizeMapping([300, 250]);
+      } else {
+        // else use banner dimensions
+        gptAdUnit.defineSizeMapping(banner);
+      }
 
       if (options.targetingKey && options.targetingValue) {
         gptAdUnit.setTargeting(options.targetingKey, options.targetingValue);

--- a/templates/feature/app/templates/embed.html
+++ b/templates/feature/app/templates/embed.html
@@ -30,9 +30,9 @@
 
   {# data-source, data-credit, and data-note are also used in the CMS #}
   <ul class="graphic-footer">
-    {% if context.embed_note %}<li data-note>Note: {{ context.embed_note }}</li>{% endif %}
-    {% if context.embed_source %}<li data-source>Source: {{ context.embed_source }}</li>{% endif %}
-    {% if context.embed_credit %}<li data-credit>Credit: {{ context.embed_credit }}</li>{% endif %}
+    {% if context.embed_note %}<li>Note: <span data-note>{{ context.embed_note }}</span></li>{% endif %}
+    {% if context.embed_source %}<li>Source: <span data-source>{{ context.embed_source }}</span></li>{% endif %}
+    {% if context.embed_credit %}<li>Credit: <span data-credit>{{ context.embed_credit }}</span></li>{% endif %}
   </ul>
 </div>
 {% endblock content %}

--- a/templates/graphic/app/templates/graphic-static.html
+++ b/templates/graphic/app/templates/graphic-static.html
@@ -14,7 +14,7 @@
 {# used by the CMS #}
 {# if this is an ai2html graphic, fill out these variables #}
 {% set graphicTitle = context.headline %}
-{% set graphicCaption = '' %}
+{% set graphicCaption = context.prose %}
 {# graphicAltText is used by the CMS for accessibility #}
 {% set graphicAltText = context.alttext %}
 {% set graphicNote = context.note %}

--- a/templates/graphic/app/templates/graphic-static.html
+++ b/templates/graphic/app/templates/graphic-static.html
@@ -14,7 +14,7 @@
 {# used by the CMS #}
 {# if this is an ai2html graphic, fill out these variables #}
 {% set graphicTitle = context.headline %}
-{% set graphicCaption = context.prose %}
+{% set graphicCaption = '' %}
 {# graphicAltText is used by the CMS for accessibility #}
 {% set graphicAltText = context.alttext %}
 {% set graphicNote = context.note %}

--- a/templates/graphic/app/templates/graphic-static.html
+++ b/templates/graphic/app/templates/graphic-static.html
@@ -37,9 +37,9 @@
 
   {# data-source and data-credit are also used in the CMS #}
   <ul class="graphic-footer">
-    {% if context.note %}<li data-note>Note: {{ context.note }}</li>{% endif %}
-    {% if context.source %}<li data-source>Source: {{ context.source }}</li>{% endif %}
-    {% if context.credit %}<li data-credit>Credit: {{ context.credit }}</li>{% endif %}
+    {% if context.note %}<li>Note: <span data-note>{{ context.note }}</span></li>{% endif %}
+    {% if context.source %}<li>Source: <span data-source>{{ context.source }}</span></li>{% endif %}
+    {% if context.credit %}<li>Credit: <span data-credit>{{ context.credit }}</span></li>{% endif %}
   </ul>
 </div>
 {% endblock content %}

--- a/templates/graphic/app/templates/graphic-static.html
+++ b/templates/graphic/app/templates/graphic-static.html
@@ -27,7 +27,7 @@
 {# data-graphic signifies that this can be embedded in the CMS #}
 <div class="app" data-graphic>
   {# data-title is used to grab the title in the CMS #}
-  <h1 class="graphic-title" data-title>{{ context.headline | widont }}</h1>
+  <h1 class="graphic-title" data-title>{{ context.headline | widont or 'The only member-supported, digital-first, nonpartisan media organization' | widont }}</h1>
   {# data-caption is used to grab the caption in the CMS #}
   <span data-caption>{{ prose(context.prose, context, graphicData) }}</span>
 

--- a/templates/graphic/app/templates/graphic.html
+++ b/templates/graphic/app/templates/graphic.html
@@ -21,7 +21,7 @@
 {# data-graphic signifies that this can be embedded in the CMS #}
 <div class="app" data-graphic>
   {# data-title is used to grab the title in the CMS #}
-  <h1 class="graphic-title" data-title>{{ context.headline | widont }}</h1>
+  <h1 class="graphic-title" data-title>{{ context.headline | widont or 'The only member-supported, digital-first, nonpartisan media organization' | widont }}</h1>
   {# data-caption is used to grab the caption in the CMS #}
   <span data-caption>{{ prose(context.prose, context, graphicData) }}</span>
 

--- a/templates/graphic/app/templates/graphic.html
+++ b/templates/graphic/app/templates/graphic.html
@@ -30,9 +30,9 @@
 
   {# data-source, data-credit, and data-note are also used in the CMS #}
   <ul class="graphic-footer">
-    {% if context.note %}<li data-note>Note: {{ context.note }}</li>{% endif %}
-    {% if context.source %}<li data-source>Source: {{ context.source }}</li>{% endif %}
-    {% if context.credit %}<li data-credit>Credit: {{ context.credit }}</li>{% endif %}
+    {% if context.note %}<li>Note: <span data-note>{{ context.note }}</span></li>{% endif %}
+    {% if context.source %}<li>Source: <span data-source>{{ context.source }}</span></li>{% endif %}
+    {% if context.credit %}<li>Credit: <span data-credit>{{ context.credit }}</span></li>{% endif %}
   </ul>
 </div>
 {% endblock content %}


### PR DESCRIPTION
## [7.4.0] - 2022-06-22

### Changed

- `templates/__common__/config/tasks/graphics-meta.js` - make sources metadata an array
- `templates/feature/app/scripts/utils/ad-loader.js` - make ad square if ad has class `dv-gpt-ad-square`
- `templates/feature/app/templates/embed.html`, `templates/graphic/app/templates/graphic-static.html` - wrap credit, note and source metadata in `data-` tags so "Credit:", "Note:" and "Source:" don't appear in metadata
- `templates/graphic/app/templates/graphic.html` - add default graphic headline and wrap credit, note and source metadata in `data-` tags