### PR TITLE
Update authorize.js to get authorization code without OOB

### DIFF
--- a/templates/__common__/utils/fetch/authorize.js
+++ b/templates/__common__/utils/fetch/authorize.js
@@ -32,7 +32,7 @@ async function getSecrets() {
 
   const googleClientId = secrets.client_id;
   const googleClientSecret = secrets.client_secret;
-  const googleRedirectUri = secrets.redirect_uris[0];
+  const googleRedirectUri = secrets.redirect_uri;
   const googleTokenFile =
     process.env.GOOGLE_TOKEN_FILE ||
     path.join(os.homedir(), '.google_drive_fetch_token');
@@ -79,8 +79,10 @@ async function getAuth() {
 function getGoogleToken(auth, googleTokenFile) {
   return new Promise((resolve, reject) => {
     const url = auth.generateAuthUrl({
-      access_type: 'offline',
       scope: SCOPES,
+      response_type: "code",
+      redirect_uri: auth.redirectUri,
+      client_id: auth._clientId
     });
 
     console.log(
@@ -96,9 +98,11 @@ function getGoogleToken(auth, googleTokenFile) {
     });
 
     rl.question(
-      colors.bold('Enter your success code from that page here:\n'),
-      async code => {
+      colors.bold("Sign in with your @texastribune.org account and hit 'Allow' to grant access to News Apps Graphics Kit.\nAfter redirected, the page looks broken, but copy the URL and paste it here:\n"),
+      async url => {
         rl.close();
+
+        const code = url.split(/[?=&]+/)[2];
 
         let tokens;
 

--- a/templates/__common__/utils/fetch/authorize.js
+++ b/templates/__common__/utils/fetch/authorize.js
@@ -98,7 +98,7 @@ function getGoogleToken(auth, googleTokenFile) {
     });
 
     rl.question(
-      colors.bold("Sign in with your @texastribune.org account and hit 'Allow' to grant access to News Apps Graphics Kit.\nAfter redirected, the page looks broken, but copy the URL and paste it here:\n"),
+      colors.bold("Sign in with your @texastribune.org account and hit 'Allow' to grant access to News Apps Graphics Kit.\nAfter you are redirected, the page will look broken, but copy the URL and paste it here:\n"),
       async url => {
         rl.close();
 


### PR DESCRIPTION
- Change parameters to pass to authorization URL the user will be prompted to access when they run `authorize.js` for the first time
- Tweak the language so that the user can correctly copy and paste the URL
- Tweak the string manipulation code so that `authorize.js` will correctly obtain the response code from google (needed to access tokens).

[Here is the basecamp doc about the issue and changes I made.](https://3.basecamp.com/3098728/buckets/80634/todos/5559902764)

**Things to keep in mind:**

- The authorization experience can be improved: That "This site can't be reached" seems broken and confusing. Is there a way to redirect to localhost and make it look not broken? Note that if we change the `redirect_uri` parameter to something that doesn't match an authorized URI, [you will get a `redirect_uri_mismatch` error](https://developers.google.com/identity/protocols/oauth2/native-app#authorization-errors-redirect-uri-mismatch).
- The documentation talks about [expiration of access tokens](https://developers.google.com/identity/protocols/oauth2/native-app#handlingresponse). I'm not so sure how long the tokens are valid, or where the expiration information is. It will be worth looking into.