### PR TITLE
Tweak so new project will work with old tt kit secret credentials

### DIFF
--- a/templates/__common__/utils/fetch/authorize.js
+++ b/templates/__common__/utils/fetch/authorize.js
@@ -32,7 +32,7 @@ async function getSecrets() {
 
   const googleClientId = secrets.client_id;
   const googleClientSecret = secrets.client_secret;
-  const googleRedirectUri = secrets.redirect_uri;
+  const googleRedirectUri = secrets.redirect_uris[0];
   const googleTokenFile =
     process.env.GOOGLE_TOKEN_FILE ||
     path.join(os.homedir(), '.google_drive_fetch_token');


### PR DESCRIPTION
Just a little tweak so that old `.tt_kit_google_client_secrets.json` will work with a new project. If a user has a `.google_drive_fetch_token` saved in their home directory, `authorize.js` will not request a new google token, but will read the `.tt_kit_google_client_secrets.json` file whenever they run commands like `npm run data:fetch` etc.

With this change:
- **An old user** (who has `.google_drive_fetch_token` and old `.tt_kit_google_client_secrets.json` credentials in their home directory) should be able to create and run commands in **a new `data-visuals-create` project** (with updated `authorized.js`)

Note on a new user:
- **A new user** (who doesn't have `.google_drive_fetch_token` saved in their home directory) can create and run commands in **a new project**, but
- **A new user** can't run commands in **an old project** if they run commands for the first time (since old `authorize.js` is designed to use an OOB option, it won't allow the new user to give permission to google). In the onboarding process, we'll have to make sure they create their test kit and run commands like `npm run data:fetch`. Once they run those commands, `.google_drive_fetch_token` will be saved in their home directory, and they should be able to run commands in **an old project**. The difference in `.tt_kit_google_client_secrets.json` or `authorize.js` shouldn't matter.

FYI:
- An **old user** should be able to run commands in **an old project** as always.