### PR TITLE
Hot Fix: comment out array transformation of a source line

### DIFF
--- a/templates/__common__/config/tasks/graphics-meta.js
+++ b/templates/__common__/config/tasks/graphics-meta.js
@@ -182,13 +182,14 @@ const parseGraphic = async (
     const note = await getText({ key: 'note', page });
     let source = await getText({ key: 'source', page });
 
-    // create array from source
-    if (source.length > 0) {
-      // separate by commas or and
-      source = source.split(/, *| and */g);
-    } else {
-      source = [];
-    }
+    // commenting this out as a hot fix in December 2022 for issue #158
+    // // create array from source
+    // if (source.length > 0) {
+    //   // separate by commas or and
+    //   source = source.split(/, *| and */g);
+    // } else {
+    //   source = [];
+    // }
 
     const links = await page.$$eval('a', links =>
       links.map(link => {


### PR DESCRIPTION
Since the spreadsheet metadata needs a string value instead of an array value, for now, just commenting out the array transformation of a source line as a hot fix until we further investigate the issue.